### PR TITLE
Implement addgroup command to add a student group to ArchDuke

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -20,23 +20,29 @@ public class AddGroupCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_GROUP_NAME + "CS2103-W16-3";
 
-    public static final String MESSAGE_ARGUMENTS = "Group added: %s";
+    public static final String MESSAGE_SUCCESS = "New student group added: %1$s";
+    public static final String MESSAGE_DUPLICATE_GROUP = "This student group already exists in ArchDuke";
 
     private final Group toAdd;
 
     /**
      * Creates an AddGroupCommand to add the specified {@code Group}
      *
-     * @param groupName of the group to be added to ArchDuke.
+     * @param group group to be added to ArchDuke.
      */
-    public AddGroupCommand(Group groupName) {
-        requireAllNonNull(groupName);
-        toAdd = groupName;
+    public AddGroupCommand(Group group) {
+        requireAllNonNull(group);
+        toAdd = group;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException(String.format(MESSAGE_ARGUMENTS, toAdd));
+        if (model.hasGroup(toAdd)) {
+            throw new CommandException(MESSAGE_DUPLICATE_GROUP);
+        }
+
+        model.addGroup(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -1,7 +1,32 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ACADEMIC_MAJOR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
 /**
- * Adds a student contact to ArchDuke.
+ * Adds a student group to ArchDuke.
  */
-public class AddGroupCommand {
+public class AddGroupCommand extends Command {
+
+    public static final String COMMAND_WORD = "addgroup";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a student group to ArchDuke. "
+            + "Parameters: "
+            + "g/" + "GROUP_NAME \n"
+            + "Example: " + COMMAND_WORD + " "
+            + "g/" + "CS2103-W16-3";
+
+    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "Addgroup command not implemented yet";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET);
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -14,9 +15,9 @@ public class AddGroupCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a student group to ArchDuke. "
             + "Parameters: "
-            + "g/" + "GROUP_NAME \n"
+            + PREFIX_GROUP_NAME + "GROUP_NAME \n"
             + "Example: " + COMMAND_WORD + " "
-            + "g/" + "CS2103-W16-3";
+            + PREFIX_GROUP_NAME + "CS2103-W16-3";
 
     public static final String MESSAGE_NOT_IMPLEMENTED_YET = "Addgroup command not implemented yet";
 

--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -5,6 +5,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.group.Group;
 
 /**
  * Adds a student group to ArchDuke.
@@ -19,18 +20,16 @@ public class AddGroupCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_GROUP_NAME + "CS2103-W16-3";
 
-    public static final String MESSAGE_NOT_IMPLEMENTED_YET = "Addgroup command not implemented yet";
-
     public static final String MESSAGE_ARGUMENTS = "Group name: %s";
 
-    private final String toAdd;
+    private final Group toAdd;
 
     /**
      * Creates an AddGroupCommand to add the specified {@code Group}
      *
      * @param groupName of the group to be added to ArchDuke.
      */
-    public AddGroupCommand(String groupName) {
+    public AddGroupCommand(Group groupName) {
         requireAllNonNull(groupName);
         toAdd = groupName;
     }

--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -1,10 +1,6 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ACADEMIC_MAJOR;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -24,9 +20,39 @@ public class AddGroupCommand extends Command {
 
     public static final String MESSAGE_NOT_IMPLEMENTED_YET = "Addgroup command not implemented yet";
 
-    @Override
-    public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException(MESSAGE_NOT_IMPLEMENTED_YET);
+    public static final String MESSAGE_ARGUMENTS = "Group name: %s";
+
+    private final String toAdd;
+
+    /**
+     * Creates an AddGroupCommand to add the specified {@code Group}
+     *
+     * @param groupName of the group to be added to ArchDuke.
+     */
+    public AddGroupCommand(String groupName) {
+        requireAllNonNull(groupName);
+        toAdd = groupName;
     }
 
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        throw new CommandException(String.format(MESSAGE_ARGUMENTS, toAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddGroupCommand)) {
+            return false;
+        }
+
+        // state check
+        AddGroupCommand e = (AddGroupCommand) other;
+        return toAdd.equals(e.toAdd);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -20,7 +20,7 @@ public class AddGroupCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_GROUP_NAME + "CS2103-W16-3";
 
-    public static final String MESSAGE_ARGUMENTS = "Group name: %s";
+    public static final String MESSAGE_ARGUMENTS = "Group added: %s";
 
     private final Group toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -1,0 +1,7 @@
+package seedu.address.logic.commands;
+
+/**
+ * Adds a student contact to ArchDuke.
+ */
+public class AddGroupCommand {
+}

--- a/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
@@ -11,6 +11,11 @@ import seedu.address.logic.parser.exceptions.ParseException;
 
 public class AddGroupCommandParser implements Parser<AddGroupCommand> {
 
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code AddGroupCommand}
+     * and returns an {@code AddGroupCommand} object for execution.
+     * @throws ParseException if the user input does not conform the expected format.
+     */
     public AddGroupCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_GROUP_NAME);

--- a/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.parser;
+
+public class AddGroupCommandParser {
+}

--- a/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
@@ -27,10 +27,9 @@ public class AddGroupCommandParser implements Parser<AddGroupCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddGroupCommand.MESSAGE_USAGE));
         }
 
-        String groupNameString = argMultimap.getValue(PREFIX_GROUP_NAME).orElse("");
-        GroupName groupName = new GroupName(groupNameString);
+        GroupName groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).orElse(""));
         Group group = new Group(groupName);
-
+        
         return new AddGroupCommand(group);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
@@ -1,4 +1,37 @@
 package seedu.address.logic.parser;
 
-public class AddGroupCommandParser {
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.AddGroupCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class AddGroupCommandParser implements Parser<AddGroupCommand> {
+
+    public AddGroupCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_GROUP_NAME);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_GROUP_NAME)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddGroupCommand.MESSAGE_USAGE));
+        }
+
+        String groupName = argMultimap.getValue(PREFIX_GROUP_NAME).orElse("");
+
+        return new AddGroupCommand(groupName);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 }
+
+

--- a/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
@@ -8,6 +8,8 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddGroupCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupName;
 
 public class AddGroupCommandParser implements Parser<AddGroupCommand> {
 
@@ -25,9 +27,11 @@ public class AddGroupCommandParser implements Parser<AddGroupCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddGroupCommand.MESSAGE_USAGE));
         }
 
-        String groupName = argMultimap.getValue(PREFIX_GROUP_NAME).orElse("");
+        String groupNameString = argMultimap.getValue(PREFIX_GROUP_NAME).orElse("");
+        GroupName groupName = new GroupName(groupNameString);
+        Group group = new Group(groupName);
 
-        return new AddGroupCommand(groupName);
+        return new AddGroupCommand(group);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
@@ -29,7 +29,7 @@ public class AddGroupCommandParser implements Parser<AddGroupCommand> {
 
         GroupName groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).orElse(""));
         Group group = new Group(groupName);
-        
+
         return new AddGroupCommand(group);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddGroupCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -67,6 +68,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case AddGroupCommand.COMMAND_WORD:
+            return new AddGroupCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -70,7 +70,7 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case AddGroupCommand.COMMAND_WORD:
-            return new AddGroupCommand();
+            return new AddGroupCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ACADEMIC_MAJOR = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_GROUP_NAME = new Prefix("g/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.group.GroupName;
 import seedu.address.model.person.AcademicMajor;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -120,5 +121,14 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    public static GroupName parseGroupName(String groupName) throws ParseException {
+        requireNonNull(groupName);
+        String trimmedName = groupName.trim();
+        if (!GroupName.isValidGroupName(trimmedName)) {
+            throw new ParseException(GroupName.MESSAGE_CONSTRAINTS);
+        }
+        return new GroupName(trimmedName);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -123,6 +123,12 @@ public class ParserUtil {
         return tagSet;
     }
 
+    /**
+     * Parses a {@code String groupName} into a {@code GroupName}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code groupName} is invalid.
+     */
     public static GroupName parseGroupName(String groupName) throws ParseException {
         requireNonNull(groupName);
         String trimmedName = groupName.trim();

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -3,8 +3,11 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.group.Group;
+import seedu.address.model.group.UniqueGroupList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -15,6 +18,7 @@ import seedu.address.model.person.UniquePersonList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
+    private final UniqueGroupList groups;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -25,6 +29,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         persons = new UniquePersonList();
+        groups = new UniqueGroupList();
     }
 
     public AddressBook() {}
@@ -48,12 +53,21 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Replaces the contents of the group list with {@code groups}.
+     * {@code groups} must not contain duplicate groups.
+     */
+    public void setGroups(List<Group> groups) {
+        this.groups.setGroups(groups);
+    }
+
+    /**
      * Resets the existing data of this {@code AddressBook} with {@code newData}.
      */
     public void resetData(ReadOnlyAddressBook newData) {
         requireNonNull(newData);
 
         setPersons(newData.getPersonList());
+        setGroups(newData.getGroupList());
     }
 
     //// person-level operations
@@ -67,11 +81,27 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if a group with the same identity as {@code group} exists in the address book.
+     */
+    public boolean hasGroup(Group group) {
+        requireNonNull(group);
+        return groups.contains(group);
+    }
+
+    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */
     public void addPerson(Person p) {
         persons.add(p);
+    }
+
+    /**
+     * Adds a person to the address book.
+     * The person must not already exist in the address book.
+     */
+    public void addGroup(Group g) {
+        groups.add(g);
     }
 
     /**
@@ -93,6 +123,14 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.remove(key);
     }
 
+    /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeGroup(Group key) {
+        groups.remove(key);
+    }
+
     //// util methods
 
     @Override
@@ -107,14 +145,20 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
+    public ObservableList<Group> getGroupList() {
+        return groups.asUnmodifiableObservableList();
+    }
+
+    @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AddressBook // instanceof handles nulls
-                && persons.equals(((AddressBook) other).persons));
+                && persons.equals(((AddressBook) other).persons)
+                && groups.equals(((AddressBook) other).groups));
     }
 
     @Override
     public int hashCode() {
-        return persons.hashCode();
+        return Objects.hash(persons.hashCode(), groups.hashCode());
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 
 /**
@@ -13,6 +14,9 @@ import seedu.address.model.person.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Group> PREDICATE_SHOW_ALL_GROUPS = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -58,16 +62,33 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
+     * Returns true if a group with the same identity as {@code group} exists in the address book.
+     */
+    boolean hasGroup(Group group);
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */
     void deletePerson(Person target);
 
     /**
+     * Deletes the given group.
+     * The group must exist in the address book.
+     */
+    void deleteGroup(Group group);
+
+    /**
      * Adds the given person.
      * {@code person} must not already exist in the address book.
      */
     void addPerson(Person person);
+
+    /**
+     * Adds the given group.
+     * {@code group} must not already exist in the address book.
+     */
+    void addGroup(Group group);
 
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
@@ -79,9 +100,18 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
+    /** Returns an unmodifiable view of the filtered group list */
+    ObservableList<Group> getFilteredGroupList();
+
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Updates the filter of the filtered group list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredGroupList(Predicate<Group> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 
 /**
@@ -22,6 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final FilteredList<Group> filteredGroups;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -34,6 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredGroups = new FilteredList<>(this.addressBook.getGroupList());
     }
 
     public ModelManager() {
@@ -94,14 +97,31 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasGroup(Group group) {
+        requireNonNull(group);
+        return addressBook.hasGroup(group);
+    }
+
+    @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
+    }
+
+    @Override
+    public void deleteGroup(Group target) {
+        addressBook.removeGroup(target);
     }
 
     @Override
     public void addPerson(Person person) {
         addressBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+    }
+
+    @Override
+    public void addGroup(Group group) {
+        addressBook.addGroup(group);
+        updateFilteredGroupList(PREDICATE_SHOW_ALL_GROUPS);
     }
 
     @Override
@@ -123,9 +143,20 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public ObservableList<Group> getFilteredGroupList() {
+        return filteredGroups;
+    }
+
+    @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredGroupList(Predicate<Group> predicate) {
+        requireNonNull(predicate);
+        filteredGroups.setPredicate(predicate);
     }
 
     @Override
@@ -144,7 +175,8 @@ public class ModelManager implements Model {
         ModelManager other = (ModelManager) obj;
         return addressBook.equals(other.addressBook)
                 && userPrefs.equals(other.userPrefs)
-                && filteredPersons.equals(other.filteredPersons);
+                && filteredPersons.equals(other.filteredPersons)
+                && filteredGroups.equals(other.filteredGroups);
     }
 
 }

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 
 /**
@@ -13,5 +14,11 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate persons.
      */
     ObservableList<Person> getPersonList();
+
+    /**
+     * Returns an unmodifiable view of the groups list.
+     * This list will not contain any duplicate groups.
+     */
+    ObservableList<Group> getGroupList();
 
 }

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -1,2 +1,4 @@
-package seedu.address.model.group;public class Group {
+package seedu.address.model.group;
+
+public class Group {
 }

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -2,7 +2,11 @@ package seedu.address.model.group;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+
+import seedu.address.model.person.Person;
 
 /**
  * Represents a Group in ArchDuke.
@@ -12,6 +16,9 @@ public class Group {
 
     // Identity fields
     private final GroupName groupName;
+
+    // Data fields
+    private final List<Person> persons = new ArrayList<>();
 
     /**
      * Constructs a {@code Group}.

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -1,7 +1,5 @@
 package seedu.address.model.group;
 
-import seedu.address.model.person.Name;
-
 /**
  * Represents a Group in ArchDuke.
  * Guarantees: details are present and not null, field values are validated, immutable.
@@ -10,4 +8,8 @@ public class Group {
 
     // Identity fields
     private final GroupName groupName;
+
+    public Group(GroupName groupName) {
+        this.groupName = groupName;
+    }
 }

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -3,10 +3,6 @@ package seedu.address.model.group;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
-import java.util.Set;
-
-import seedu.address.model.person.Person;
-import seedu.address.model.tag.Tag;
 
 /**
  * Represents a Group in ArchDuke.

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -2,7 +2,11 @@ package seedu.address.model.group;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
+import java.util.Set;
+
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 
 /**
  * Represents a Group in ArchDuke.
@@ -42,5 +46,42 @@ public class Group {
                 && otherGroup.getGroupName().equals(getGroupName());
     }
 
-    
+    /**
+     * Checks if both groups have the same identity and data fields.
+     * This defines a stronger notion of equality between two groups.
+     *
+     * @param other Another group object.
+     * @return true as a boolean value if both groups have the same identity and data fields.
+     */
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles null
+        if (!(other instanceof Group)) {
+            return false;
+        }
+
+        Group otherGroup = (Group) other;
+        return otherGroup.getGroupName().equals(getGroupName());
+    }
+
+    @Override
+    public int hashCode() {
+        // use this method for custom fields hashing instead of implementing your own
+        return Objects.hash(groupName);
+    }
+
+    /**
+     * Returns a String representation of a group.
+     *
+     * @return String representation of a group.
+     */
+    @Override
+    public String toString() {
+        return String.valueOf(getGroupName());
+    }
 }

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -1,5 +1,9 @@
 package seedu.address.model.group;
 
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.model.person.Person;
+
 /**
  * Represents a Group in ArchDuke.
  * Guarantees: details are present and not null, field values are validated, immutable.
@@ -9,7 +13,34 @@ public class Group {
     // Identity fields
     private final GroupName groupName;
 
+    /**
+     * Constructs a {@code Group}.
+     *
+     * @param groupName A valid group name.
+     */
     public Group(GroupName groupName) {
+        requireNonNull(groupName);
         this.groupName = groupName;
     }
+
+    public GroupName getGroupName() {
+        return groupName;
+    }
+
+    /**
+     * Compares as a weaker notion of identity between two groups.
+     *
+     * @param otherGroup Another group object.
+     * @return true as a boolean value if both groups have the same group name.
+     */
+    public boolean isSameGroup(Group otherGroup) {
+        if (otherGroup == this) {
+            return true;
+        }
+
+        return otherGroup != null
+                && otherGroup.getGroupName().equals(getGroupName());
+    }
+
+    
 }

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -1,4 +1,13 @@
 package seedu.address.model.group;
 
+import seedu.address.model.person.Name;
+
+/**
+ * Represents a Group in ArchDuke.
+ * Guarantees: details are present and not null, field values are validated, immutable.
+ */
 public class Group {
+
+    // Identity fields
+    private final GroupName groupName;
 }

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -1,0 +1,2 @@
+package seedu.address.model.group;public class Group {
+}

--- a/src/main/java/seedu/address/model/group/GroupName.java
+++ b/src/main/java/seedu/address/model/group/GroupName.java
@@ -41,9 +41,9 @@ public class GroupName {
     }
 
     /**
-     * Returns a String representation of group name.
+     * Returns a String representation of a group name.
      *
-     * @return String representation of group name.
+     * @return String representation of a group name.
      */
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/model/group/GroupName.java
+++ b/src/main/java/seedu/address/model/group/GroupName.java
@@ -3,8 +3,6 @@ package seedu.address.model.group;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
-import seedu.address.logic.commands.AddGroupCommand;
-
 /**
  * Represents a Group's name in ArchDuke.
  * Guarantees: immutable; is valid as declared in {@link #isValidGroupName(String)}

--- a/src/main/java/seedu/address/model/group/GroupName.java
+++ b/src/main/java/seedu/address/model/group/GroupName.java
@@ -1,0 +1,4 @@
+package seedu.address.model.group;
+
+public class GroupName {
+}

--- a/src/main/java/seedu/address/model/group/GroupName.java
+++ b/src/main/java/seedu/address/model/group/GroupName.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class GroupName {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Group names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Group name can take any values, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String groupName;
 

--- a/src/main/java/seedu/address/model/group/GroupName.java
+++ b/src/main/java/seedu/address/model/group/GroupName.java
@@ -1,4 +1,75 @@
 package seedu.address.model.group;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import seedu.address.logic.commands.AddGroupCommand;
+
+/**
+ * Represents a Group's name in ArchDuke.
+ * Guarantees: immutable; is valid as declared in {@link #isValidGroupName(String)}
+ */
 public class GroupName {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Group names should only contain alphanumeric characters and spaces, and it should not be blank";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    public final String groupName;
+
+    /**
+     * Constructs a {@code GroupName}.
+     *
+     * @param groupName A valid group name.
+     */
+    public GroupName(String groupName) {
+        requireNonNull(groupName);
+        checkArgument(isValidGroupName(groupName), MESSAGE_CONSTRAINTS);
+        this.groupName = groupName;
+    }
+
+    /**
+     * Returns true if a given string is a valid group name.
+     */
+    public static boolean isValidGroupName(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns a String representation of group name.
+     *
+     * @return String representation of group name.
+     */
+    @Override
+    public String toString() {
+        return groupName;
+    }
+
+    /**
+     * Checks whether the specified other object is equal to GroupName object.
+     *
+     * @param other The other object.
+     * @return true as boolean value if the specified other object is equal to the GroupName object.
+     */
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles null
+        if (!(other instanceof GroupName)) {
+            return false;
+        }
+        
+        // state check
+        GroupName e = (GroupName) other;
+        return groupName.equals(e.groupName);
+    }
 }

--- a/src/main/java/seedu/address/model/group/GroupName.java
+++ b/src/main/java/seedu/address/model/group/GroupName.java
@@ -67,7 +67,7 @@ public class GroupName {
         if (!(other instanceof GroupName)) {
             return false;
         }
-        
+
         // state check
         GroupName e = (GroupName) other;
         return groupName.equals(e.groupName);

--- a/src/main/java/seedu/address/model/group/UniqueGroupList.java
+++ b/src/main/java/seedu/address/model/group/UniqueGroupList.java
@@ -30,21 +30,21 @@ public class UniqueGroupList implements Iterable<Group> {
     /**
      * Returns true if the list contains an equivalent group as the given argument.
      */
-    public boolean contains(Group toCheck) {
-        requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::isSameGroup);
+    public boolean contains(Group grouptoCheck) {
+        requireNonNull(grouptoCheck);
+        return internalList.stream().anyMatch(grouptoCheck::isSameGroup);
     }
 
     /**
      * Adds a group to the list.
      * The group must not already exist in the list.
      */
-    public void add(Group toAdd) {
-        requireNonNull(toAdd);
-        if (contains(toAdd)) {
+    public void add(Group groupToAdd) {
+        requireNonNull(groupToAdd);
+        if (contains(groupToAdd)) {
             throw new DuplicatePersonException();
         }
-        internalList.add(toAdd);
+        internalList.add(groupToAdd);
     }
 
     /**

--- a/src/main/java/seedu/address/model/group/UniqueGroupList.java
+++ b/src/main/java/seedu/address/model/group/UniqueGroupList.java
@@ -1,0 +1,136 @@
+package seedu.address.model.group;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.group.exceptions.GroupNotFoundException;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+
+/**
+ * A list of groups that enforces uniqueness between its elements and does not allow nulls.
+ * A group is considered unique by comparing using {@code Group#isSameGroup(Group)}. As such, adding and updating of
+ * groups uses Group#isSameGroup(Group) for equality so as to ensure that the group being added or updated is
+ * unique in terms of identity in the UniqueGroupList. However, the removal of a group uses Group#equals(Object) so
+ * as to ensure that the group with exactly the same fields will be removed.
+ *
+ * Supports a minimal set of list operations.
+ *
+ * @see Group#isSameGroup(Group)
+ */
+public class UniqueGroupList implements Iterable<Group> {
+    private final ObservableList<Group> internalList = FXCollections.observableArrayList();
+    private final ObservableList<Group> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent group as the given argument.
+     */
+    public boolean contains(Group toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().anyMatch(toCheck::isSameGroup);
+    }
+
+    /**
+     * Adds a group to the list.
+     * The group must not already exist in the list.
+     */
+    public void add(Group toAdd) {
+        requireNonNull(toAdd);
+        if (contains(toAdd)) {
+            throw new DuplicatePersonException();
+        }
+        internalList.add(toAdd);
+    }
+
+    /**
+     * Replaces the group {@code target} in the list with {@code editedGroup}.
+     * {@code target} must exist in the list.
+     * The group identity of {@code editedGroup} must not be the same as another existing group in the list.
+     */
+    public void setGroup(Group target, Group editedGroup) {
+        requireAllNonNull(target, editedGroup);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new GroupNotFoundException();
+        }
+
+        if (!target.isSameGroup(editedGroup) && contains(editedGroup)) {
+            throw new DuplicatePersonException();
+        }
+
+        internalList.set(index, editedGroup);
+    }
+
+    /**
+     * Removes the equivalent group from the list.
+     * The group must exist in the list.
+     */
+    public void remove(Group toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new GroupNotFoundException();
+        }
+    }
+
+    public void setGroups(UniqueGroupList replacement) {
+        requireNonNull(replacement);
+        internalList.setAll(replacement.internalList);
+    }
+
+    /**
+     * Replaces the contents of this list with {@code groups}.
+     * {@code groups} must not contain duplicate groups.
+     */
+    public void setGroups(List<Group> groups) {
+        requireAllNonNull(groups);
+        if (!groupsAreUnique(groups)) {
+            throw new DuplicatePersonException();
+        }
+
+        internalList.setAll(groups);
+    }
+
+    /**
+     * Returns the backing list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Group> asUnmodifiableObservableList() {
+        return internalUnmodifiableList;
+    }
+
+    @Override
+    public Iterator<Group> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UniqueGroupList // instanceof handles nulls
+                && internalList.equals(((UniqueGroupList) other).internalList));
+    }
+
+    @Override
+    public int hashCode() {
+        return internalList.hashCode();
+    }
+
+    /**
+     * Returns true if {@code groups} contains only unique groups.
+     */
+    private boolean groupsAreUnique(List<Group> groups) {
+        for (int i = 0; i < groups.size() - 1; i++) {
+            for (int j = i + 1; j < groups.size(); j++) {
+                if (groups.get(i).isSameGroup(groups.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/seedu/address/model/group/exceptions/DuplicateGroupException.java
+++ b/src/main/java/seedu/address/model/group/exceptions/DuplicateGroupException.java
@@ -1,0 +1,7 @@
+package seedu.address.model.group.exceptions;
+
+public class DuplicateGroupException extends RuntimeException {
+    public DuplicateGroupException() {
+        super("Operation would result in duplicate groups");
+    }
+}

--- a/src/main/java/seedu/address/model/group/exceptions/GroupNotFoundException.java
+++ b/src/main/java/seedu/address/model/group/exceptions/GroupNotFoundException.java
@@ -1,0 +1,4 @@
+package seedu.address.model.group.exceptions;
+
+public class GroupNotFoundException extends RuntimeException {
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -44,8 +44,8 @@ public class SampleDataUtil {
 
     public static Group[] getSampleGroups() {
         return new Group[] {
-                new Group(new GroupName("NUS Fintech Society")),
-                new Group(new GroupName("NUS Data Science Society"))
+            new Group(new GroupName("NUS Fintech Society")),
+            new Group(new GroupName("NUS Data Science Society"))
         };
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -6,6 +6,8 @@ import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupName;
 import seedu.address.model.person.AcademicMajor;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -40,11 +42,23 @@ public class SampleDataUtil {
         };
     }
 
+    public static Group[] getSampleGroups() {
+        return new Group[] {
+                new Group(new GroupName("NUS Fintech Society")),
+                new Group(new GroupName("NUS Data Science Society"))
+        };
+    }
+
     public static ReadOnlyAddressBook getSampleAddressBook() {
         AddressBook sampleAb = new AddressBook();
         for (Person samplePerson : getSamplePersons()) {
             sampleAb.addPerson(samplePerson);
         }
+
+        for (Group sampleGroup : getSampleGroups()) {
+            sampleAb.addGroup(sampleGroup);
+        }
+
         return sampleAb;
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedGroup.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedGroup.java
@@ -1,0 +1,53 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupName;
+
+/**
+ * Jackson-friendly version of {@link Group}.
+ */
+public class JsonAdaptedGroup {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Group's %s field is missing!";
+
+    private final String groupName;
+
+    /**
+     * Constructs a {@code JsonAdaptedGroup} with the given person details.
+     */
+    @JsonCreator
+    public JsonAdaptedGroup(@JsonProperty("groupName") String groupName) {
+        this.groupName = groupName;
+    }
+
+    /**
+     * Converts a given {@code Group} into this class for Jackson use.
+     */
+    public JsonAdaptedGroup(seedu.address.model.group.Group source) {
+        groupName = String.valueOf(source.getGroupName());
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted person object into the model's {@code Person} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted person.
+     */
+    public Group toModelType() throws IllegalValueException {
+
+        if (groupName == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    GroupName.class.getSimpleName()));
+        }
+
+        if (!GroupName.isValidGroupName(groupName)) {
+            throw new IllegalValueException(GroupName.MESSAGE_CONSTRAINTS);
+        }
+        final GroupName modelGroupName = new GroupName(groupName);
+
+        return new Group(modelGroupName);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -15,7 +15,7 @@ import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 
 /**
- * An Immutable AddressBook that is serializable to JSON format.
+ * An Immutable ArchDuke that is serializable to JSON format.
  */
 @JsonRootName(value = "addressbook")
 class JsonSerializableAddressBook {

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 
 /**
@@ -20,15 +21,22 @@ import seedu.address.model.person.Person;
 class JsonSerializableAddressBook {
 
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
+    public static final String MESSAGE_DUPLICATE_GROUP = "Groups list contains duplicate group(s).";
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
+    private final List<JsonAdaptedGroup> groups = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableAddressBook} with the given persons.
      */
     @JsonCreator
-    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons) {
+    public JsonSerializableAddressBook(@JsonProperty("persons") List<JsonAdaptedPerson> persons,
+                                       @JsonProperty("groups") List<JsonAdaptedGroup> groups) {
         this.persons.addAll(persons);
+
+        if (groups != null) {
+            this.groups.addAll(groups);
+        }
     }
 
     /**
@@ -38,6 +46,7 @@ class JsonSerializableAddressBook {
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
+        groups.addAll(source.getGroupList().stream().map(JsonAdaptedGroup::new).collect(Collectors.toList()));
     }
 
     /**
@@ -54,6 +63,15 @@ class JsonSerializableAddressBook {
             }
             addressBook.addPerson(person);
         }
+
+        for (JsonAdaptedGroup jsonAdaptedGroup : groups) {
+            Group group = jsonAdaptedGroup.toModelType();
+            if (addressBook.hasGroup(group)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_GROUP);
+            }
+            addressBook.addGroup(group);
+        }
+
         return addressBook;
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -6,21 +6,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
-import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.testutil.ModelStub;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -72,81 +67,6 @@ public class AddCommandTest {
 
         // different person -> returns false
         assertFalse(addAliceCommand.equals(addBobCommand));
-    }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddGroupCommandTest.java
@@ -1,0 +1,12 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class AddGroupCommandTest {
+    @Test
+    public void constructor_nullGroup_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddGroupCommand(null));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -37,6 +37,9 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
+    public static final String VALID_GROUP_NAME_NUS_FINTECH_SOCIETY = "NUS Fintech Society";
+    public static final String VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY = "NUS Data Science Society";
+
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
@@ -90,6 +91,7 @@ public class AddressBookTest {
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
+        private final ObservableList<Group> groups = FXCollections.observableArrayList();
 
         AddressBookStub(Collection<Person> persons) {
             this.persons.setAll(persons);
@@ -99,6 +101,12 @@ public class AddressBookTest {
         public ObservableList<Person> getPersonList() {
             return persons;
         }
+
+        @Override
+        public ObservableList<Group> getGroupList() {
+            return groups;
+        }
+
     }
 
 }

--- a/src/test/java/seedu/address/model/group/GroupNameTest.java
+++ b/src/test/java/seedu/address/model/group/GroupNameTest.java
@@ -1,0 +1,2 @@
+package seedu.address.model.group;public class GroupNameTest {
+}

--- a/src/test/java/seedu/address/model/group/GroupNameTest.java
+++ b/src/test/java/seedu/address/model/group/GroupNameTest.java
@@ -1,2 +1,39 @@
-package seedu.address.model.group;public class GroupNameTest {
+package seedu.address.model.group;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class GroupNameTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new GroupName(null));
+    }
+
+    @Test
+    public void constructor_invalidGroupName_throwsIllegalArgumentException() {
+        String invalidGroupName = "";
+        assertThrows(IllegalArgumentException.class, () -> new GroupName(invalidGroupName));
+    }
+
+    @Test
+    public void isValidGroupName() {
+        // null group name
+        assertThrows(NullPointerException.class, () -> GroupName.isValidGroupName(null));
+
+        // invalid group name
+        assertFalse(GroupName.isValidGroupName("")); // empty string
+        assertFalse(GroupName.isValidGroupName(" ")); // spaces only
+
+        // valid name
+        assertTrue(GroupName.isValidGroupName("coffee enthusiasts")); // alphabets only
+        assertTrue(GroupName.isValidGroupName("31415")); // numbers only
+        assertTrue(GroupName.isValidGroupName("2nd year students")); // alphanumeric characters
+        assertTrue(GroupName.isValidGroupName("NUS Fintech Society")); // with capital letters
+        assertTrue(GroupName.isValidGroupName("NUS Statistics and Data Science Society")); // long names
+        assertTrue(GroupName.isValidGroupName("important*")); // contains non-alphanumeric characters
+        assertTrue(GroupName.isValidGroupName("^")); // only non-alphanumeric characters
+    }
 }

--- a/src/test/java/seedu/address/model/group/GroupTest.java
+++ b/src/test/java/seedu/address/model/group/GroupTest.java
@@ -1,2 +1,4 @@
-package seedu.address.model.group;public class GroupTest {
+package seedu.address.model.group;
+
+public class GroupTest {
 }

--- a/src/test/java/seedu/address/model/group/GroupTest.java
+++ b/src/test/java/seedu/address/model/group/GroupTest.java
@@ -20,17 +20,17 @@ public class GroupTest {
         assertFalse(NUS_FINTECH_SOCIETY.isSameGroup(null));
 
         // same name -> returns true
-        Group editedNUSFintechSociety = new GroupBuilder(NUS_FINTECH_SOCIETY).build();
-        assertTrue(NUS_FINTECH_SOCIETY.isSameGroup(editedNUSFintechSociety));
+        Group editedNusFintechSociety = new GroupBuilder(NUS_FINTECH_SOCIETY).build();
+        assertTrue(NUS_FINTECH_SOCIETY.isSameGroup(editedNusFintechSociety));
 
         // different name -> returns false
-        editedNUSFintechSociety = new GroupBuilder(NUS_FINTECH_SOCIETY)
+        editedNusFintechSociety = new GroupBuilder(NUS_FINTECH_SOCIETY)
                 .withGroupName(VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY).build();
-        assertFalse(NUS_FINTECH_SOCIETY.isSameGroup(editedNUSFintechSociety));
+        assertFalse(NUS_FINTECH_SOCIETY.isSameGroup(editedNusFintechSociety));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_GROUP_NAME_NUS_FINTECH_SOCIETY + " ";
-        editedNUSFintechSociety = new GroupBuilder(NUS_FINTECH_SOCIETY).withGroupName(nameWithTrailingSpaces).build();
-        assertFalse(NUS_FINTECH_SOCIETY.isSameGroup(editedNUSFintechSociety));
+        editedNusFintechSociety = new GroupBuilder(NUS_FINTECH_SOCIETY).withGroupName(nameWithTrailingSpaces).build();
+        assertFalse(NUS_FINTECH_SOCIETY.isSameGroup(editedNusFintechSociety));
     }
 }

--- a/src/test/java/seedu/address/model/group/GroupTest.java
+++ b/src/test/java/seedu/address/model/group/GroupTest.java
@@ -1,17 +1,36 @@
 package seedu.address.model.group;
 
-
-import static seedu.address.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
+import static seedu.address.testutil.TypicalGroups.NUS_FINTECH_SOCIETY;
 
 import org.junit.jupiter.api.Test;
 
-
 import seedu.address.testutil.GroupBuilder;
-
 
 public class GroupTest {
     @Test
     public void isSameGroup() {
+        // same object -> returns true
+        assertTrue(NUS_FINTECH_SOCIETY.isSameGroup(NUS_FINTECH_SOCIETY));
 
+        // null -> returns false
+        assertFalse(NUS_FINTECH_SOCIETY.isSameGroup(null));
+
+        // same name -> returns true
+        Group editedNUSFintechSociety = new GroupBuilder(NUS_FINTECH_SOCIETY).build();
+        assertTrue(NUS_FINTECH_SOCIETY.isSameGroup(editedNUSFintechSociety));
+
+        // different name -> returns false
+        editedNUSFintechSociety = new GroupBuilder(NUS_FINTECH_SOCIETY)
+                .withGroupName(VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY).build();
+        assertFalse(NUS_FINTECH_SOCIETY.isSameGroup(editedNUSFintechSociety));
+
+        // name has trailing spaces, all other attributes same -> returns false
+        String nameWithTrailingSpaces = VALID_GROUP_NAME_NUS_FINTECH_SOCIETY + " ";
+        editedNUSFintechSociety = new GroupBuilder(NUS_FINTECH_SOCIETY).withGroupName(nameWithTrailingSpaces).build();
+        assertFalse(NUS_FINTECH_SOCIETY.isSameGroup(editedNUSFintechSociety));
     }
 }

--- a/src/test/java/seedu/address/model/group/GroupTest.java
+++ b/src/test/java/seedu/address/model/group/GroupTest.java
@@ -1,4 +1,17 @@
 package seedu.address.model.group;
 
+
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+
+import seedu.address.testutil.GroupBuilder;
+
+
 public class GroupTest {
+    @Test
+    public void isSameGroup() {
+
+    }
 }

--- a/src/test/java/seedu/address/model/group/GroupTest.java
+++ b/src/test/java/seedu/address/model/group/GroupTest.java
@@ -1,0 +1,2 @@
+package seedu.address.model.group;public class GroupTest {
+}

--- a/src/test/java/seedu/address/testutil/GroupBuilder.java
+++ b/src/test/java/seedu/address/testutil/GroupBuilder.java
@@ -1,0 +1,39 @@
+package seedu.address.testutil;
+
+import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupName;
+
+/**
+ * A utility class to help with building Group objects.
+ */
+public class GroupBuilder {
+    public static final String GROUP_NAME = "NUS Fintech Society";
+
+    private GroupName groupName;
+
+    /**
+     * Creates a {@code GroupBuilder} with the default details.
+     */
+    public GroupBuilder() {
+        groupName = new GroupName(GROUP_NAME);
+    }
+
+    /**
+     * Initializes the GroupBuilder with the data of {@code groupToCopy}.
+     */
+    public GroupBuilder(Group groupToCopy) {
+        groupName = groupToCopy.getGroupName();
+    }
+
+    /**
+     * Sets the {@code GroupName} of the {@code Group} that we are building.
+     */
+    public GroupBuilder withGroupName(String groupName) {
+        this.groupName = new GroupName(groupName);
+        return this;
+    }
+
+    public Group build() {
+        return new Group(groupName);
+    }
+}

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -1,0 +1,112 @@
+package seedu.address.testutil;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.group.Group;
+import seedu.address.model.person.Person;
+
+/**
+ * A default model stub that have all of the methods failing.
+ */
+public class ModelStub implements Model {
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Path getAddressBookFilePath() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBookFilePath(Path addressBookFilePath) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addPerson(Person person) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addGroup(Group group) {
+
+    }
+
+    @Override
+    public void setAddressBook(ReadOnlyAddressBook newData) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasPerson(Person person) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasGroup(Group group) {
+        return false;
+    }
+
+    @Override
+    public void deletePerson(Person target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteGroup(Group group) {
+
+    }
+
+    @Override
+    public void setPerson(Person target, Person editedPerson) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Person> getFilteredPersonList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Group> getFilteredGroupList() {
+        return null;
+    }
+
+    @Override
+    public void updateFilteredPersonList(Predicate<Person> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredGroupList(Predicate<Group> predicate) {
+
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalGroups.java
+++ b/src/test/java/seedu/address/testutil/TypicalGroups.java
@@ -12,7 +12,8 @@ import seedu.address.model.group.Group;
  */
 public class TypicalGroups {
     public static final Group NUS_FINTECH_SOCIETY = new GroupBuilder().withGroupName("NUS Fintech Society").build();
-    public static final Group NUS_DATA_SCIENCE_SOCIETY = new GroupBuilder().withGroupName("NUS Data Science Society").build();
+    public static final Group NUS_DATA_SCIENCE_SOCIETY =
+            new GroupBuilder().withGroupName("NUS Data Science Society").build();
 
     /**
      * Returns an {@code AddressBook} with all the typical groups.

--- a/src/test/java/seedu/address/testutil/TypicalGroups.java
+++ b/src/test/java/seedu/address/testutil/TypicalGroups.java
@@ -12,7 +12,7 @@ import seedu.address.model.group.Group;
  */
 public class TypicalGroups {
     public static final Group NUS_FINTECH_SOCIETY = new GroupBuilder().withGroupName("NUS Fintech Society").build();
-    public static final Group RVRC_RUNNERS = new GroupBuilder().withGroupName("RVRC Runners").build();
+    public static final Group NUS_DATA_SCIENCE_SOCIETY = new GroupBuilder().withGroupName("NUS Data Science Society").build();
 
     /**
      * Returns an {@code AddressBook} with all the typical groups.
@@ -26,6 +26,6 @@ public class TypicalGroups {
     }
 
     public static List<Group> getTypicalGroups() {
-        return new ArrayList<>(Arrays.asList(NUS_FINTECH_SOCIETY, RVRC_RUNNERS));
+        return new ArrayList<>(Arrays.asList(NUS_FINTECH_SOCIETY, NUS_DATA_SCIENCE_SOCIETY));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalGroups.java
+++ b/src/test/java/seedu/address/testutil/TypicalGroups.java
@@ -1,0 +1,8 @@
+package seedu.address.testutil;
+
+/**
+ * A utility class containing a list of {@code Group} objects to be used in tests.
+ */
+public class TypicalGroups {
+    
+}

--- a/src/test/java/seedu/address/testutil/TypicalGroups.java
+++ b/src/test/java/seedu/address/testutil/TypicalGroups.java
@@ -1,8 +1,31 @@
 package seedu.address.testutil;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.group.Group;
+
 /**
  * A utility class containing a list of {@code Group} objects to be used in tests.
  */
 public class TypicalGroups {
-    
+    public static final Group NUS_FINTECH_SOCIETY = new GroupBuilder().withGroupName("NUS Fintech Society").build();
+    public static final Group RVRC_RUNNERS = new GroupBuilder().withGroupName("RVRC Runners").build();
+
+    /**
+     * Returns an {@code AddressBook} with all the typical groups.
+     */
+    public static AddressBook getTypicalAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Group group : getTypicalGroups()) {
+            ab.addGroup(group);
+        }
+        return ab;
+    }
+
+    public static List<Group> getTypicalGroups() {
+        return new ArrayList<>(Arrays.asList(NUS_FINTECH_SOCIETY, RVRC_RUNNERS));
+    }
 }


### PR DESCRIPTION
Summary of implementation: 

* Hook `addgroup` command into ArchDuke, with the same format as the UG.
* `GROUP_NAME` cannot be an empty string or have leading whitespaces.
* A `group` is identified uniquely by its `GROUP_NAME`, no two `Group` can have the same `GROUP_NAME`.
* Implement parser methods for `addgroup` command.
* ArchDuke now contains a unique group list.
* Implement storing of new `Group` into ArchDuke's unique group list. 
* `Group` in ArchDuke can now be stored in json format in ArchDuke.
* Add sample group data into ArchDuke.
* Implement some unit tests for methods, directly and indirectly, related to `Group`.

Change of file structure:
* `ModelStub` class is removed from `AddCommandTest` class because ArchDuke `model` now contains `Group`.
* `ModelStub` class is now moved under `testutil` package so that it is more natural for it to be able to contain other methods that are not related to `AddCommand`
 
 Explanation: `ModelStub` used to implement `Model` interface. This would mean that class `ModelStub` in `AddCommandTest` would need to override all the `Group` methods in `Model` which is unnecessary. 