### PR TITLE
Implement delgroup command to delete an existing group

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
@@ -9,6 +12,12 @@ import seedu.address.model.Model;
 public class DeleteGroupCommand extends Command {
 
     public static final String COMMAND_WORD = "delgroup";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a task from a group."
+            + "Parameters: "
+            + PREFIX_GROUP_NAME + "TASK_NAME \n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_GROUP_NAME + "CS2103-W16-3 \n";
 
     @Override
     public CommandResult execute(Model model) throws CommandException {

--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -1,0 +1,17 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Deletes a student group from ArchDuke.
+ */
+public class DeleteGroupCommand extends Command {
+
+    public static final String COMMAND_WORD = "delgroup";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        return new CommandResult("Hello from delgroup command");
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -5,11 +5,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 
 import java.util.List;
 
-import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.group.Group;
-import seedu.address.model.person.Person;
 
 /**
  * Deletes a student group from ArchDuke.

--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;

--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -1,9 +1,15 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.group.Group;
+import seedu.address.model.person.Person;
 
 /**
  * Deletes a student group from ArchDuke.
@@ -18,8 +24,48 @@ public class DeleteGroupCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_GROUP_NAME + "CS2103-W16-3 \n";
 
+    public static final String MESSAGE_NON_EXISTENT_GROUP = "This group does not exist in the list";
+
+    public static final String MESSAGE_DELETE_GROUP_SUCCESS = "Deleted group: %1$s";
+
+    private final Group group;
+
+    /**
+     * Creates a DeleteGroupCommand to delete the specified {@code Group}
+     */
+    public DeleteGroupCommand(Group group) {
+        requireNonNull(group);
+        this.group = group;
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return new CommandResult("Hello from delgroup command");
+        requireNonNull(model);
+        List<Group> lastShownList = model.getFilteredGroupList();
+
+        if (!lastShownList.contains(group)) {
+            throw new CommandException(MESSAGE_NON_EXISTENT_GROUP);
+        }
+
+        Group groupToDelete = group;
+        model.deleteGroup(groupToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_GROUP_SUCCESS, groupToDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles null
+        if (!(other instanceof DeleteGroupCommand)) {
+            return false;
+        }
+
+        // state check
+        DeleteGroupCommand e = (DeleteGroupCommand) other;
+        return group.equals(e.group);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -75,7 +75,7 @@ public class AddressBookParser {
             return new AddGroupCommandParser().parse(arguments);
 
         case DeleteGroupCommand.COMMAND_WORD:
-            return new DeleteGroupCommand();
+            return new DeleteGroupCommandParser().parse(arguments);
 
         case AddTaskCommand.COMMAND_WORD:
             return new AddTaskCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.AddTaskCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteGroupCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -72,6 +73,9 @@ public class AddressBookParser {
 
         case AddGroupCommand.COMMAND_WORD:
             return new AddGroupCommandParser().parse(arguments);
+
+        case DeleteGroupCommand.COMMAND_WORD:
+            return new DeleteGroupCommand();
 
         case AddTaskCommand.COMMAND_WORD:
             return new AddTaskCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/DeleteGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteGroupCommandParser.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 
 import java.util.stream.Stream;
 
-import seedu.address.logic.commands.AddGroupCommand;
 import seedu.address.logic.commands.DeleteGroupCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.group.Group;

--- a/src/main/java/seedu/address/logic/parser/DeleteGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteGroupCommandParser.java
@@ -1,8 +1,12 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.AddGroupCommand;
 import seedu.address.logic.commands.DeleteGroupCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.group.Group;
@@ -23,9 +27,22 @@ public class DeleteGroupCommandParser implements Parser<DeleteGroupCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_GROUP_NAME);
 
+        if (!arePrefixesPresent(argMultimap, PREFIX_GROUP_NAME)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteGroupCommand.MESSAGE_USAGE));
+        }
+
         GroupName groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).orElse(""));
         Group group = new Group(groupName);
 
         return new DeleteGroupCommand(group);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteGroupCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+
+import seedu.address.logic.commands.DeleteGroupCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupName;
+
+/**
+ * Parses input arguments and creates a new DeleteGroupCommand object.
+ */
+public class DeleteGroupCommandParser implements Parser<DeleteGroupCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteGroupCommand
+     * and returns a DeleteGroupCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteGroupCommand parse(String args) throws ParseException {
+
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_GROUP_NAME);
+
+        GroupName groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).orElse(""));
+        Group group = new Group(groupName);
+
+        return new DeleteGroupCommand(group);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -52,10 +52,10 @@ public class CommandTestUtil {
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
-    public static final String GROUP_DESC_NUS_FINTECH_SOCIETY = " " +
-            PREFIX_GROUP_NAME + VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
-    public static final String GROUP_DESC_NUS_DATA_SCIENCE_SOCIETY = " " +
-            PREFIX_GROUP_NAME + VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY;
+    public static final String GROUP_DESC_NUS_FINTECH_SOCIETY = " " + PREFIX_GROUP_NAME
+            + VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
+    public static final String GROUP_DESC_NUS_DATA_SCIENCE_SOCIETY = " " + PREFIX_GROUP_NAME
+            + VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ACADEMIC_MAJOR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -50,6 +51,11 @@ public class CommandTestUtil {
     public static final String ACADEMIC_MAJOR_DESC_BOB = " " + PREFIX_ACADEMIC_MAJOR + VALID_ACADEMIC_MAJOR_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+
+    public static final String GROUP_DESC_NUS_FINTECH_SOCIETY = " " +
+            PREFIX_GROUP_NAME + VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
+    public static final String GROUP_DESC_NUS_DATA_SCIENCE_SOCIETY = " " +
+            PREFIX_GROUP_NAME + VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones

--- a/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
@@ -1,2 +1,14 @@
-package seedu.address.logic.commands;public class DeleteGroupCommandTest {
+package seedu.address.logic.commands;
+
+import static seedu.address.testutil.TypicalGroups.getTypicalAddressBook;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for DeleteGroupCommand.
+ */
+public class DeleteGroupCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.commands;public class DeleteGroupCommandTest {
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddGroupCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -23,9 +24,12 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
+import seedu.address.testutil.GroupBuilder;
+import seedu.address.testutil.GroupUtil;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
 
@@ -38,6 +42,13 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
         assertEquals(new AddCommand(person), command);
+    }
+
+    @Test
+    public void parseCommand_addGroup() throws Exception {
+        Group group = new GroupBuilder().build();
+        AddGroupCommand command = (AddGroupCommand) parser.parseCommand(GroupUtil.getAddGroupCommand(group));
+        assertEquals(new AddGroupCommand(group), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteGroupCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteGroupCommandParserTest.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.commands.CommandTestUtil.GROUP_DESC_NUS_FINTECH_SOCIETY;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.model.group.GroupName.MESSAGE_CONSTRAINTS;
+import static seedu.address.testutil.TypicalGroups.NUS_FINTECH_SOCIETY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeleteGroupCommand;
+import seedu.address.model.group.Group;
+import seedu.address.testutil.GroupBuilder;
+
+public class DeleteGroupCommandParserTest {
+
+    private DeleteGroupCommandParser parser = new DeleteGroupCommandParser();
+
+    Group expectedGroup = new GroupBuilder(NUS_FINTECH_SOCIETY).build();
+
+    @Test
+    public void parse_validArgs_returnsDeleteGroupCommand() {
+        assertParseSuccess(parser, GROUP_DESC_NUS_FINTECH_SOCIETY, new DeleteGroupCommand(expectedGroup));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, " ", MESSAGE_CONSTRAINTS);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteGroupCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteGroupCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.commands.CommandTestUtil.GROUP_DESC_NUS_FINTECH_SOCIETY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.model.group.GroupName.MESSAGE_CONSTRAINTS;
@@ -25,6 +26,6 @@ public class DeleteGroupCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, " ", MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " " + PREFIX_GROUP_NAME, MESSAGE_CONSTRAINTS);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteGroupCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteGroupCommandParserTest.java
@@ -17,7 +17,7 @@ public class DeleteGroupCommandParserTest {
 
     private DeleteGroupCommandParser parser = new DeleteGroupCommandParser();
 
-    Group expectedGroup = new GroupBuilder(NUS_FINTECH_SOCIETY).build();
+    private Group expectedGroup = new GroupBuilder(NUS_FINTECH_SOCIETY).build();
 
     @Test
     public void parse_validArgs_returnsDeleteGroupCommand() {

--- a/src/test/java/seedu/address/testutil/GroupUtil.java
+++ b/src/test/java/seedu/address/testutil/GroupUtil.java
@@ -1,0 +1,25 @@
+package seedu.address.testutil;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+
+import seedu.address.logic.commands.AddGroupCommand;
+import seedu.address.model.group.Group;
+
+public class GroupUtil {
+
+    /**
+     * Returns an addgroup command string for adding the {@code group}.
+     */
+    public static String getAddGroupCommand(Group group) {
+        return AddGroupCommand.COMMAND_WORD + " " + getGroupDetails(group);
+    }
+
+    /**
+     * Returns the part of command string for the given {@code group}'s details.
+     */
+    public static String getGroupDetails(Group group) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(PREFIX_GROUP_NAME + group.getGroupName().groupName + " ");
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Command format: `delgroup g/GROUP_NAME`

Summary of implementation: 
* Throw the correct error when the user inputs `delgroup`
* Same as `addgroup` command, GroupName in `addgroup`cannot be blank and preceded with whitespace. This means that if the user input GroupName with preceding whitespace the group would still be identified by the name after the spaces are removed. 

Example:

`delgroup g/NUS Fintech Society` is equivalent to `delgroup g/               NUS Fintech Society`

* Throw the correct error when user attempts to delete a non-existing group from ArchDuke
* Wrote some basic test cases
* As per `addgroup` command, please note that GroupName is case sensitive 