### PR TITLE
Add DeleteTaskCommand class to create the command object

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -18,7 +18,7 @@ public class DeleteGroupCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a group from ArchDuke."
             + "Parameters: "
-            + PREFIX_GROUP_NAME + "TASK_NAME \n"
+            + PREFIX_GROUP_NAME + "GROUP_NAME \n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_GROUP_NAME + "CS2103-W16-3 \n";
 

--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -16,7 +16,7 @@ public class DeleteGroupCommand extends Command {
 
     public static final String COMMAND_WORD = "delgroup";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a task from a group."
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a group from ArchDuke."
             + "Parameters: "
             + PREFIX_GROUP_NAME + "TASK_NAME \n"
             + "Example: " + COMMAND_WORD + " "

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
@@ -9,6 +12,14 @@ import seedu.address.model.Model;
 public class DeleteTaskCommand extends Command {
 
     public static final String COMMAND_WORD = "deltask";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes an existing task from an existing group."
+            + "Parameters: "
+            + PREFIX_TASK + "TASK_NAME "
+            + PREFIX_GROUP_NAME + "GROUP_NAME \n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_TASK + "v1.2 user guide "
+            + PREFIX_GROUP_NAME + "CS2103-W16-3 \n";
 
     @Override
     public CommandResult execute(Model model) throws CommandException {

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -1,10 +1,13 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.group.Group;
+import seedu.address.model.task.Task;
 
 /**
  * Deletes an existing task from ArchDuke.
@@ -21,8 +24,37 @@ public class DeleteTaskCommand extends Command {
             + PREFIX_TASK + "v1.2 user guide "
             + PREFIX_GROUP_NAME + "CS2103-W16-3 \n";
 
+    public static final String MESSAGE_ARGUMENTS = "Task: %1$s, Group: %2$s";
+
+    private final Task task;
+    private final Group group;
+
+    public DeleteTaskCommand(Task task, Group group) {
+        requireAllNonNull(task, group);
+
+        this.task = task;
+        this.group = group;
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return new CommandResult("Hello from deltask");
+        throw new CommandException(String.format(MESSAGE_ARGUMENTS, task, group));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof DeleteTaskCommand)) {
+            return false;
+        }
+
+        // state check
+        DeleteTaskCommand e = (DeleteTaskCommand) other;
+        return task.equals(e.task) && group.equals(e.group);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -1,8 +1,11 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK;
+
+import java.util.List;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -24,7 +27,11 @@ public class DeleteTaskCommand extends Command {
             + PREFIX_TASK + "v1.2 user guide "
             + PREFIX_GROUP_NAME + "CS2103-W16-3 \n";
 
-    public static final String MESSAGE_ARGUMENTS = "Task: %1$s, Group: %2$s";
+    public static final String MESSAGE_NON_EXISTENT_TASK = "This task does not exist in the specified group.";
+
+    public static final String MESSAGE_NON_EXISTENT_GROUP = "This group does not exist in the list";
+
+    public static final String MESSAGE_DELETE_TASK_SUCCESS = "Deleted task: %1$s";
 
     private final Task task;
     private final Group group;
@@ -38,7 +45,17 @@ public class DeleteTaskCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException(String.format(MESSAGE_ARGUMENTS, task, group));
+        requireNonNull(model);
+
+        if (model.hasGroup(group)) { //check whether the specified group exists
+            if (!model.hasTask(task, group)) {
+                throw new CommandException(MESSAGE_NON_EXISTENT_TASK);
+            }
+            model.deleteTask(task, group);
+            return new CommandResult(String.format(MESSAGE_DELETE_TASK_SUCCESS, task));
+        } else {
+            throw new CommandException(MESSAGE_NON_EXISTENT_GROUP);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -3,10 +3,15 @@ package seedu.address.logic.commands;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
+/**
+ * Deletes an existing task from ArchDuke.
+ */
 public class DeleteTaskCommand extends Command {
+
+    public static final String COMMAND_WORD = "deltask";
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return null;
+        return new CommandResult("Hello from deltask");
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -5,8 +5,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK;
 
-import java.util.List;
-
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.group.Group;
@@ -36,6 +34,13 @@ public class DeleteTaskCommand extends Command {
     private final Task task;
     private final Group group;
 
+    /**
+     * Creates a DeleteTaskCommand to delete the specified {@code Task}
+     * in the specified {@code Group}
+     *
+     * @param task Task to be deleted.
+     * @param group Group in which the task to be deleted exists.
+     */
     public DeleteTaskCommand(Task task, Group group) {
         requireAllNonNull(task, group);
 

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.group.Group;
 import seedu.address.model.task.Task;
 
 /**
- * Deletes an existing task from ArchDuke.
+ * Deletes an existing task from an existing group in ArchDuke.
  */
 public class DeleteTaskCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -1,0 +1,12 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+public class DeleteTaskCommand extends Command {
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        return null;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -82,7 +82,7 @@ public class AddressBookParser {
             return new AddTaskCommandParser().parse(arguments);
 
         case DeleteTaskCommand.COMMAND_WORD:
-            return new DeleteTaskCommand();
+            return new DeleteTaskCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteGroupCommand;
+import seedu.address.logic.commands.DeleteTaskCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -79,6 +80,9 @@ public class AddressBookParser {
 
         case AddTaskCommand.COMMAND_WORD:
             return new AddTaskCommandParser().parse(arguments);
+
+        case DeleteTaskCommand.COMMAND_WORD:
+            return new DeleteTaskCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.parser;public class DeleteTaskCommandParser {
+}

--- a/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteTaskCommandParser.java
@@ -1,2 +1,52 @@
-package seedu.address.logic.parser;public class DeleteTaskCommandParser {
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.DeleteTaskCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupName;
+import seedu.address.model.task.Task;
+import seedu.address.model.task.TaskName;
+
+/**
+ * Parses input arguments and creates a new DeleteTaskCommand object.
+ */
+public class DeleteTaskCommandParser implements Parser<DeleteTaskCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteTaskCommand
+     * and returns a DeleteTaskCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteTaskCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_TASK, PREFIX_GROUP_NAME);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_TASK, PREFIX_GROUP_NAME)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteTaskCommand.MESSAGE_USAGE));
+        }
+
+        TaskName taskName = ParserUtil.parseTaskName(argMultimap.getValue(PREFIX_TASK).orElse(""));
+        Task task = new Task(taskName);
+
+        GroupName groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).orElse(""));
+        Group group = new Group(groupName);
+
+        return new DeleteTaskCommand(task, group);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -11,6 +11,7 @@ import seedu.address.model.group.UniqueGroupList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 import seedu.address.model.task.Task;
+import seedu.address.model.task.UniqueTaskList;
 
 /**
  * Wraps all data at the address-book level
@@ -20,6 +21,7 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
     private final UniqueGroupList groups;
+    private final UniqueTaskList tasks;
 
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -31,6 +33,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     {
         persons = new UniquePersonList();
         groups = new UniqueGroupList();
+        tasks = new UniqueTaskList();
     }
 
     public AddressBook() {}
@@ -116,9 +119,9 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Adds a task into a specified group to the address book.
+     * Adds a task from a specified group from the address book.
      * The group must already exist in the address book.
-     * The task must not already exist in the specified group in the address book.
+     * The task must already exist in the specified group in the address book.
      */
     public void addTask(Task task, Group g) {
         groups.getGroup(g).addTask(task);
@@ -150,6 +153,15 @@ public class AddressBook implements ReadOnlyAddressBook {
         groups.remove(key);
     }
 
+    /**
+     * Removes a task from a specified group from the address book.
+     * The group must already exist in the address book.
+     * The task must already exist in the specified group in the address book.
+     */
+    public void removeTask(Task task, Group g) {
+        groups.getGroup(g).removeTask(task);
+    }
+
     //// util methods
 
     @Override
@@ -166,6 +178,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public ObservableList<Group> getGroupList() {
         return groups.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public ObservableList<Task> getTaskList() {
+        return tasks.asUnmodifiableObservableList();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -119,9 +119,9 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Adds a task from a specified group from the address book.
+     * Adds a task to a specified group from the address book.
      * The group must already exist in the address book.
-     * The task must already exist in the specified group in the address book.
+     * The task must not already exist in the specified group in the address book.
      */
     public void addTask(Task task, Group g) {
         groups.getGroup(g).addTask(task);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -85,6 +85,13 @@ public interface Model {
     void deleteGroup(Group group);
 
     /**
+     * Deletes the given task in the given group.
+     * The group must exist in the address book.
+     * The task must exist in the specified group.
+     */
+    void deleteTask(Task task, Group group);
+
+    /**
      * Adds the given person.
      * {@code person} must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -121,6 +121,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void deleteTask(Task task, Group group) {
+        addressBook.removeTask(task, group);
+        updateFilteredGroupList(PREDICATE_SHOW_ALL_GROUPS);
+    }
+
+    @Override
     public void addPerson(Person person) {
         addressBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import javafx.collections.ObservableList;
 import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
+import seedu.address.model.task.Task;
 
 /**
  * Unmodifiable view of an address book
@@ -20,5 +21,11 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate groups.
      */
     ObservableList<Group> getGroupList();
+
+    /**
+     * Returns an unmodifiable view of the tasks list.
+     * This list will not contain any duplicate tasks.
+     */
+    ObservableList<Task> getTaskList();
 
 }

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -62,6 +62,15 @@ public class Group {
     }
 
     /**
+     * Deletes a task from this specific group.
+     *
+     * @param task Tasks to be removed.
+     */
+    public void removeTask(Task task) {
+        tasks.remove(task);
+    }
+
+    /**
      * Retrieves the UniqueTaskList from this specific group
      *
      */

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -53,11 +53,11 @@ public class Task {
         }
 
         // instanceof handles null
-        if (!(other instanceof seedu.address.model.task.Task)) {
+        if (!(other instanceof Task)) {
             return false;
         }
 
-        seedu.address.model.task.Task otherTask = (seedu.address.model.task.Task) other;
+        Task otherTask = (Task) other;
         return otherTask.getTaskName().equals(getTaskName());
     }
 

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -18,7 +18,7 @@ public class Task {
         this.taskName = task;
     }
 
-    public TaskName getTask() {
+    public TaskName getTaskName() {
         return taskName;
     }
 
@@ -34,7 +34,7 @@ public class Task {
         }
 
         return otherTask != null
-                && otherTask.getTask().equals(getTask());
+                && otherTask.getTaskName().equals(getTaskName());
     }
 
 
@@ -58,7 +58,7 @@ public class Task {
         }
 
         seedu.address.model.task.Task otherTask = (seedu.address.model.task.Task) other;
-        return otherTask.getTask().equals(getTask());
+        return otherTask.getTaskName().equals(getTaskName());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/UniqueTaskList.java
+++ b/src/main/java/seedu/address/model/task/UniqueTaskList.java
@@ -56,7 +56,7 @@ public class UniqueTaskList implements Iterable<Task> {
      * {@code target} must exist in the list.
      * The task identity of {@code editedTask} must not be the same as another existing task in the list.
      */
-    public void setTask(Task target, Task editedTask) {
+    public void setTasks(Task target, Task editedTask) {
         requireAllNonNull(target, editedTask);
 
         int index = internalList.indexOf(target);

--- a/src/main/java/seedu/address/model/task/UniqueTaskList.java
+++ b/src/main/java/seedu/address/model/task/UniqueTaskList.java
@@ -52,6 +52,17 @@ public class UniqueTaskList implements Iterable<Task> {
     }
 
     /**
+     * Removes the equivalent task from the list.
+     * The task must exist in the list.
+     */
+    public void remove(Task toRemove) {
+        requireNonNull(toRemove);
+        if (!internalList.remove(toRemove)) {
+            throw new TaskNotFoundException();
+        }
+    }
+
+    /**
      * Replaces the task {@code target} in the list with {@code editedTask}.
      * {@code target} must exist in the list.
      * The task identity of {@code editedTask} must not be the same as another existing task in the list.
@@ -69,17 +80,6 @@ public class UniqueTaskList implements Iterable<Task> {
         }
 
         internalList.set(index, editedTask);
-    }
-
-    /**
-     * Removes the equivalent task from the list.
-     * The task must exist in the list.
-     */
-    public void remove(Task toRemove) {
-        requireNonNull(toRemove);
-        if (!internalList.remove(toRemove)) {
-            throw new TaskNotFoundException();
-        }
     }
 
     public void setTasks(UniqueTaskList replacement) {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -28,11 +28,14 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.group.Group;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.task.Task;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.GroupBuilder;
 import seedu.address.testutil.GroupUtil;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
+import seedu.address.testutil.TaskBuilder;
+import seedu.address.testutil.TaskUtil;
 
 public class AddressBookParserTest {
 
@@ -67,7 +70,10 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_deleteTask() throws Exception {
-        assertTrue(parser.parseCommand(DeleteTaskCommand.COMMAND_WORD) instanceof DeleteTaskCommand);
+        Group group = new GroupBuilder().build();
+        Task task = new TaskBuilder().build();
+        DeleteTaskCommand command = (DeleteTaskCommand) parser.parseCommand(TaskUtil.getDeleteTaskCommand(task, group));
+        assertEquals(new DeleteTaskCommand(task, group), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddGroupCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteTaskCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
@@ -62,6 +63,11 @@ public class AddressBookParserTest {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
                 DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+    }
+
+    @Test
+    public void parseCommand_deleteTask() throws Exception {
+        assertTrue(parser.parseCommand(DeleteTaskCommand.COMMAND_WORD) instanceof DeleteTaskCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -21,6 +21,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.task.Task;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddressBookTest {
@@ -92,6 +93,7 @@ public class AddressBookTest {
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
         private final ObservableList<Group> groups = FXCollections.observableArrayList();
+        private final ObservableList<Task> tasks = FXCollections.observableArrayList();
 
         AddressBookStub(Collection<Person> persons) {
             this.persons.setAll(persons);
@@ -105,6 +107,11 @@ public class AddressBookTest {
         @Override
         public ObservableList<Group> getGroupList() {
             return groups;
+        }
+
+        @Override
+        public ObservableList<Task> getTaskList() {
+            return tasks;
         }
 
     }

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -93,7 +93,12 @@ public class ModelStub implements Model {
 
     @Override
     public void deleteGroup(Group group) {
+        throw new AssertionError("This method should not be called.");
+    }
 
+    @Override
+    public void deleteTask(Task task, Group group) {
+        throw new AssertionError("This method should not be called.");
     }
 
     @Override
@@ -118,6 +123,6 @@ public class ModelStub implements Model {
 
     @Override
     public void updateFilteredGroupList(Predicate<Group> predicate) {
-
+        throw new AssertionError("This method should not be called.");
     }
 }

--- a/src/test/java/seedu/address/testutil/TaskBuilder.java
+++ b/src/test/java/seedu/address/testutil/TaskBuilder.java
@@ -1,12 +1,10 @@
 package seedu.address.testutil;
 
-import seedu.address.model.group.Group;
-import seedu.address.model.group.GroupName;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.TaskName;
 
 /**
- * A utility class to help with building Group objects.
+ * A utility class to help with building Task objects.
  */
 public class TaskBuilder {
     public static final String TASK_NAME = "Department Meeting";

--- a/src/test/java/seedu/address/testutil/TaskBuilder.java
+++ b/src/test/java/seedu/address/testutil/TaskBuilder.java
@@ -1,0 +1,41 @@
+package seedu.address.testutil;
+
+import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupName;
+import seedu.address.model.task.Task;
+import seedu.address.model.task.TaskName;
+
+/**
+ * A utility class to help with building Group objects.
+ */
+public class TaskBuilder {
+    public static final String TASK_NAME = "Department Meeting";
+
+    private TaskName taskName;
+
+    /**
+     * Creates a {@code GroupBuilder} with the default details.
+     */
+    public TaskBuilder() {
+        taskName = new TaskName(TASK_NAME);
+    }
+
+    /**
+     * Initializes the TaskBuilder with the data of {@code taskToCopy}.
+     */
+    public TaskBuilder(Task taskToCopy) {
+        taskName = taskToCopy.getTaskName();
+    }
+
+    /**
+     * Sets the {@code TaskName} of the {@code Task} that we are building.
+     */
+    public TaskBuilder withTaskName(String taskName) {
+        this.taskName = new TaskName(taskName);
+        return this;
+    }
+
+    public Task build() {
+        return new Task(taskName);
+    }
+}

--- a/src/test/java/seedu/address/testutil/TaskUtil.java
+++ b/src/test/java/seedu/address/testutil/TaskUtil.java
@@ -1,0 +1,36 @@
+package seedu.address.testutil;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK;
+
+import seedu.address.logic.commands.DeleteTaskCommand;
+import seedu.address.model.group.Group;
+import seedu.address.model.task.Task;
+
+public class TaskUtil {
+
+    /**
+     * Returns an add command string for adding the {@code person}.
+     */
+    public static String getDeleteTaskCommand(Task task, Group group) {
+        return DeleteTaskCommand.COMMAND_WORD + " " + getTaskDetails(task) + getGroupDetails(group);
+    }
+
+    /**
+     * Returns the part of command string for the given {@code group}'s details.
+     */
+    public static String getGroupDetails(Group group) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(PREFIX_GROUP_NAME + group.getGroupName().groupName + " ");
+        return sb.toString();
+    }
+
+    /**
+     * Returns the part of command string for the given {@code task}'s details.
+     */
+    public static String getTaskDetails(Task task) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(PREFIX_TASK + task.getTaskName().taskName + " ");
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Command format: `detask task/TASK_NAME g/GROUP_NAME`

Summary of implementation:

* Throw the correct error when the user inputs deltask only
* Same as `addtask` command, `TaskName` in `addtask` cannot be blank and preceded with whitespace. This means that if the user input `TaskName` with preceding whitespace the `Task` would still be identified by the name after the spaces are removed.

Example:

`deltask task/research on OCR g/ML Group Project` is equivalent to `deltask task/      research on OCR g/ML Group Project`

* Throw the correct error when user attempts to delete a task from non-existing group from ArchDuke
* Throw the correct error when user attempts to delete a non-existing task from an existing group in ArchDuke
* Throw the correct error when the user attempts to delete a non-existing task from a non-existing group
* Wrote some basic test cases
* As per addgroup command, please note that GroupName is case sensitive
* Have checked that if I close and open the app again, the same data instances would be stored