### PR TITLE
Add ViewTaskCommand class

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ViewTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewTaskCommand.java
@@ -20,7 +20,8 @@ public class ViewTaskCommand extends Command {
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_GROUP_NAME + "CS2103-W16-3";
 
-    public static final String MESSAGE_ARGUMENTS = "View task in group %1$s";
+    public static final String MESSAGE_NON_EXISTENT_GROUP = "This group does not exist in the list";
+    public static final String MESSAGE_SUCCESS = "Here are the tasks in this group: %s";
 
     private final Group group;
 
@@ -37,7 +38,11 @@ public class ViewTaskCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException(String.format(MESSAGE_ARGUMENTS, group));
+        if (model.hasGroup(group)) { //check whether the specified group exists
+            return new CommandResult(model.viewTask(group));
+        } else {
+            throw new CommandException(MESSAGE_NON_EXISTENT_GROUP);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ViewTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewTaskCommand.java
@@ -1,7 +1,11 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.group.Group;
 
 /**
  * Views tasks in the specific group in ArchDuke.
@@ -10,8 +14,46 @@ public class ViewTaskCommand extends Command {
 
     public static final String COMMAND_WORD = "viewtask";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Views tasks in a specified group in ArchDuke. "
+            + "Parameters: "
+            + PREFIX_GROUP_NAME + "GROUP_NAME \n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_GROUP_NAME + "CS2103-W16-3";
+
+    public static final String MESSAGE_ARGUMENTS = "View task in group %1$s";
+
+    private final Group group;
+
+    /**
+     * Constructs a {@code ViewTaskCommand} with the specified field.
+     *
+     * @param group The group in which the tasks would be viewed.
+     */
+    public ViewTaskCommand(Group group) {
+        requireNonNull(group);
+
+        this.group = group;
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return new CommandResult("Hello from viewtask");
+        throw new CommandException(String.format(MESSAGE_ARGUMENTS, group));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles null
+        if (!(other instanceof ViewTaskCommand)) {
+            return false;
+        }
+
+        // state check
+        ViewTaskCommand e = (ViewTaskCommand) other;
+        return group.equals(e.group);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewTaskCommand.java
@@ -1,0 +1,17 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Views tasks in the specific group in ArchDuke.
+ */
+public class ViewTaskCommand extends Command {
+
+    public static final String COMMAND_WORD = "viewtask";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        return new CommandResult("Hello from viewtask");
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ViewTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -83,6 +84,9 @@ public class AddressBookParser {
 
         case DeleteTaskCommand.COMMAND_WORD:
             return new DeleteTaskCommandParser().parse(arguments);
+
+        case ViewTaskCommand.COMMAND_WORD:
+            return new ViewTaskCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/ViewTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewTaskCommandParser.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.ViewTaskCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupName;
+
+public class ViewTaskCommandParser implements Parser<ViewTaskCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code ViewTaskCommand}
+     * and returns an {@code ViewTaskCommand} object for execution.
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    @Override
+    public ViewTaskCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_GROUP_NAME);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_GROUP_NAME)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewTaskCommand.MESSAGE_USAGE));
+        }
+
+        GroupName groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).orElse(""));
+        Group group = new Group(groupName);
+
+        return new ViewTaskCommand(group);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -162,6 +162,14 @@ public class AddressBook implements ReadOnlyAddressBook {
         groups.getGroup(g).removeTask(task);
     }
 
+    /**
+     * Views tasks from a specified group from the address book.
+     * The group must already exist in the address book.
+     */
+    public String viewTask(Group g) {
+        return groups.getGroup(g).viewTask();
+    }
+
     //// util methods
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -19,6 +19,9 @@ public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Group> PREDICATE_SHOW_ALL_GROUPS = unused -> true;
 
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Task> PREDICATE_SHOW_ALL_TASKS = unused -> true;
+
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */
@@ -112,6 +115,13 @@ public interface Model {
     void addTask(Task task, Group group);
 
     /**
+     * Views the task into the specified group.
+     * {@code group} must exists in the address book.
+     *
+     */
+    String viewTask(Group group);
+
+    /**
      * Replaces the given person {@code target} with {@code editedPerson}.
      * {@code target} must exist in the address book.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
@@ -124,6 +134,9 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered group list */
     ObservableList<Group> getFilteredGroupList();
 
+    /** Returns an unmodifiable view of the filtered group list */
+    ObservableList<Task> getFilteredTaskList();
+
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
@@ -135,4 +148,10 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredGroupList(Predicate<Group> predicate);
+
+    /**
+     * Updates the filter of the filtered group list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredTaskList(Predicate<Task> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -25,6 +25,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
     private final FilteredList<Group> filteredGroups;
+    private final FilteredList<Task> filteredTasks;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -38,6 +39,7 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         filteredGroups = new FilteredList<>(this.addressBook.getGroupList());
+        filteredTasks = new FilteredList<>(this.addressBook.getTaskList());
     }
 
     public ModelManager() {
@@ -127,6 +129,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public String viewTask(Group group) {
+        return addressBook.viewTask(group);
+    }
+
+    @Override
     public void addPerson(Person person) {
         addressBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
@@ -167,6 +174,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public ObservableList<Task> getFilteredTaskList() {
+        return filteredTasks;
+    }
+
+    @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
@@ -176,6 +188,12 @@ public class ModelManager implements Model {
     public void updateFilteredGroupList(Predicate<Group> predicate) {
         requireNonNull(predicate);
         filteredGroups.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredTaskList(Predicate<Task> predicate) {
+        requireNonNull(predicate);
+        filteredTasks.setPredicate(predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.UniqueTaskList;
@@ -71,7 +72,19 @@ public class Group {
     }
 
     /**
-     * Retrieves the UniqueTaskList from this specific group
+     * Views a task from this specific group.
+     */
+    public String viewTask() {
+        ObservableList<Task> taskList = tasks.asUnmodifiableObservableList();
+        String output = "Here are the tasks in the group: \n";
+        for (int i = 0; i < taskList.size(); i++) {
+            output += taskList.get(i).getTaskName().taskName + "\n";
+        }
+        return output;
+    }
+
+    /**
+     * Retrieves the UniqueTaskList from this specific group.
      *
      */
     public UniqueTaskList getTaskList() {

--- a/src/main/java/seedu/address/model/task/UniqueTaskList.java
+++ b/src/main/java/seedu/address/model/task/UniqueTaskList.java
@@ -115,8 +115,8 @@ public class UniqueTaskList implements Iterable<Task> {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof seedu.address.model.task.UniqueTaskList // instanceof handles nulls
-                && internalList.equals(((seedu.address.model.task.UniqueTaskList) other).internalList));
+                || (other instanceof UniqueTaskList // instanceof handles nulls
+                && internalList.equals(((UniqueTaskList) other).internalList));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/ViewTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewTaskCommandTest.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.GroupBuilder;
@@ -14,6 +17,17 @@ public class ViewTaskCommandTest {
         // same value --> returns true
         ViewTaskCommand commandWithSameValues = new ViewTaskCommand(new GroupBuilder()
                 .withGroupName("NUS Fintech Society").build());
-    }
 
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object --> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null --> return false
+        assertFalse(standardCommand.equals(null));
+
+        // different group -> returns false
+        assertFalse(standardCommand.equals(new ViewTaskCommand(new GroupBuilder()
+                .withGroupName("NUS Data Science Society").build())));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/ViewTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewTaskCommandTest.java
@@ -1,0 +1,19 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.GroupBuilder;
+
+public class ViewTaskCommandTest {
+
+    @Test
+    public void equals() {
+        final ViewTaskCommand standardCommand = new ViewTaskCommand( new GroupBuilder()
+                .withGroupName("NUS Fintech Society").build());
+
+        // same value --> returns true
+        ViewTaskCommand commandWithSameValues = new ViewTaskCommand(new GroupBuilder()
+                .withGroupName("NUS Fintech Society").build());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -24,6 +24,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ViewTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.group.Group;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -74,6 +75,13 @@ public class AddressBookParserTest {
         Task task = new TaskBuilder().build();
         DeleteTaskCommand command = (DeleteTaskCommand) parser.parseCommand(TaskUtil.getDeleteTaskCommand(task, group));
         assertEquals(new DeleteTaskCommand(task, group), command);
+    }
+
+    @Test
+    public void parseCommand_viewTask() throws Exception {
+        Group group = new GroupBuilder().build();
+        ViewTaskCommand command = (ViewTaskCommand) parser.parseCommand(TaskUtil.getViewTaskCommand(group));
+        assertEquals(new ViewTaskCommand(group), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ViewTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewTaskCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ViewTaskCommand;
+import seedu.address.testutil.GroupBuilder;
+
+public class ViewTaskCommandParserTest {
+    private ViewTaskCommandParser parser = new ViewTaskCommandParser();
+    private final String nonEmptyGroupName = "NUS Fintech Society";
+
+    @Test
+    public void parse_groupSpecified_success() {
+        // have group name
+        String userInput = " " + PREFIX_GROUP_NAME + nonEmptyGroupName;
+        ViewTaskCommand expectedCommand = new ViewTaskCommand(new GroupBuilder().build());
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingCompulsoryField_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewTaskCommand.MESSAGE_USAGE);
+
+        // no group name
+        assertParseFailure(parser, ViewTaskCommand.COMMAND_WORD, expectedMessage);
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -107,6 +107,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public String viewTask(Group group) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public ObservableList<Person> getFilteredPersonList() {
         throw new AssertionError("This method should not be called.");
     }
@@ -117,12 +122,22 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public ObservableList<Task> getFilteredTaskList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         throw new AssertionError("This method should not be called.");
     }
 
     @Override
     public void updateFilteredGroupList(Predicate<Group> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredTaskList(Predicate<Task> predicate) {
         throw new AssertionError("This method should not be called.");
     }
 }

--- a/src/test/java/seedu/address/testutil/TaskUtil.java
+++ b/src/test/java/seedu/address/testutil/TaskUtil.java
@@ -4,16 +4,24 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK;
 
 import seedu.address.logic.commands.DeleteTaskCommand;
+import seedu.address.logic.commands.ViewTaskCommand;
 import seedu.address.model.group.Group;
 import seedu.address.model.task.Task;
 
 public class TaskUtil {
 
     /**
-     * Returns an add command string for adding the {@code person}.
+     * Returns an delete task command string for deleting the {@code task}.
      */
     public static String getDeleteTaskCommand(Task task, Group group) {
         return DeleteTaskCommand.COMMAND_WORD + " " + getTaskDetails(task) + getGroupDetails(group);
+    }
+
+    /**
+     * Returns an view task command string for view the {@code task}.
+     */
+    public static String getViewTaskCommand(Group group) {
+        return ViewTaskCommand.COMMAND_WORD + " " + getGroupDetails(group);
     }
 
     /**


### PR DESCRIPTION
Command format: `viewtask g/GROUP_NAME`

Summary of implementation: 
* Allows users to view tasks in the tasklist of that particular group. The result would be displayed on the result display.
* Check that the correct error is thrown when the user only input "viewtask"
* Check that the correct error is thrown when the user input group that does not exist in ArchDuke.
* Check that it is ok if there is no task in the task list.
* Check that all the tasks are displayed properly.