### PR TITLE
Refactor FindCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -22,7 +22,7 @@ public class FindCommand extends Command {
             + "Attributes can be accessed by adding prefixes before the keywords.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + " alice bob charlie "
-            + "or " + COMMAND_WORD + " " + PREFIX_ACADEMIC_MAJOR + "Computer Science";
+            + "or " + COMMAND_WORD + " " + PREFIX_ACADEMIC_MAJOR + " Computer Science";
 
     private final AttributeContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -21,8 +21,8 @@ public class FindCommand extends Command {
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Attributes can be accessed by adding prefixes before the keywords.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + " alice bob charlie "
-            + "or " + COMMAND_WORD + " " + PREFIX_ACADEMIC_MAJOR + " Computer Science";
+            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "alice bob charlie "
+            + "or " + COMMAND_WORD + " " + PREFIX_ACADEMIC_MAJOR + "Computer Science";
 
     private final AttributeContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,27 +1,32 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ACADEMIC_MAJOR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.AttributeContainsKeywordsPredicate;
+
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
+ * Finds and lists all persons in address book whose attribute contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose attributes contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Attributes can be accessed by adding prefixes before the keywords.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + " alice bob charlie "
+            + "or " + COMMAND_WORD + " " + PREFIX_ACADEMIC_MAJOR + "Computer Science";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final AttributeContainsKeywordsPredicate predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(AttributeContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,26 +1,22 @@
 package seedu.address.logic.parser;
 
-import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ACADEMIC_MAJOR;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
-import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.AcademicMajor;
 import seedu.address.model.person.AcademicMajorContainsKeywordsPredicate;
 import seedu.address.model.person.AttributeContainsKeywordsPredicate;
-import seedu.address.model.person.Email;
 import seedu.address.model.person.EmailContainsKeywordsPredicate;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.Phone;
 import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.tag.TagContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -39,111 +35,40 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] keywords;
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE,
+                        PREFIX_EMAIL, PREFIX_ACADEMIC_MAJOR, PREFIX_TAG);
+
         if (args.contains(PREFIX_NAME.getPrefix())) {
-            keywords = parseName(args).split("\\s+");
+            String[] keywords = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get())
+                    .toString().split("\\s+");
             AttributeContainsKeywordsPredicate type = new NameContainsKeywordsPredicate(Arrays.asList(keywords));
             return new FindCommand(type);
         } else if (args.contains(PREFIX_PHONE.getPrefix())) {
-            keywords = parsePhone(args).split("\\s+");
+            String[] keywords = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get())
+                    .toString().split("\\s+");
             AttributeContainsKeywordsPredicate type = new PhoneContainsKeywordsPredicate(Arrays.asList(keywords));
             return new FindCommand(type);
         } else if (args.contains(PREFIX_EMAIL.getPrefix())) {
-            keywords = parseEmail(args).split("\\s+");
+            String[] keywords = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get())
+                    .toString().split("\\s+");
             AttributeContainsKeywordsPredicate type = new EmailContainsKeywordsPredicate(Arrays.asList(keywords));
             return new FindCommand(type);
         } else if (args.contains(PREFIX_ACADEMIC_MAJOR.getPrefix())) {
-            keywords = parseAcademicMajor(args).split("\\s+");
+            String[] keywords = ParserUtil.parseAcademicMajor(argMultimap.getValue(PREFIX_ACADEMIC_MAJOR).get())
+                    .toString().split("\\s+");
             AttributeContainsKeywordsPredicate type =
                     new AcademicMajorContainsKeywordsPredicate(Arrays.asList(keywords));
+            return new FindCommand(type);
+        } else if (args.contains(PREFIX_TAG.getPrefix())) {
+            String[] keywords = ParserUtil.parseName(argMultimap.getValue(PREFIX_TAG).get())
+                    .toString().split("\\s+");
+            AttributeContainsKeywordsPredicate type =
+                    new TagContainsKeywordsPredicate(Arrays.asList(keywords));
             return new FindCommand(type);
         } else {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
-    }
-
-    /**
-     * Parses the given {@code String} of arguments into a {@code String name}
-     * which will be used for {@code FindCommandParser} object for execution.
-     * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the user input does not conform to {@code Name} format.
-     */
-    public String parseName(String args) throws ParseException {
-        requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME);
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        }
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        return name.fullName;
-    }
-
-    /**
-     * Parses the given {@code String} of arguments into a {@code String phone}
-     * which will be used for {@code FindCommandParser} object for execution.
-     * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the user input does not conform to {@code Phone} format.
-     */
-    public String parsePhone(String args) throws ParseException {
-        requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_PHONE);
-        if (!arePrefixesPresent(argMultimap, PREFIX_PHONE)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        }
-        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        return phone.value;
-    }
-
-    /**
-     * Parses the given {@code String} of arguments into a {@code String email}
-     * which will be used for {@code FindCommandParser} object for execution.
-     * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the user input does not conform to {@code Email} format.
-     */
-    public String parseEmail(String args) throws ParseException {
-        requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_EMAIL);
-        if (!arePrefixesPresent(argMultimap, PREFIX_EMAIL)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        }
-        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        return email.value;
-    }
-
-    /**
-     * Parses the given {@code String} of arguments into a {@code String academicMajor}
-     * which will be used for {@code FindCommandParser} object for execution.
-     * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the user input does not conform to {@code AcademicMajor} format.
-     */
-    public String parseAcademicMajor(String args) throws ParseException {
-        requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_ACADEMIC_MAJOR);
-        if (!arePrefixesPresent(argMultimap, PREFIX_ACADEMIC_MAJOR)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        }
-        AcademicMajor academicMajor = ParserUtil.parseAcademicMajor(argMultimap.getValue(PREFIX_ACADEMIC_MAJOR).get());
-        return academicMajor.value;
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,26 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ACADEMIC_MAJOR;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 
 import java.util.Arrays;
+import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.AcademicMajor;
+import seedu.address.model.person.AcademicMajorContainsKeywordsPredicate;
+import seedu.address.model.person.AttributeContainsKeywordsPredicate;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -25,9 +39,111 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        String[] keywords;
+        if (args.contains(PREFIX_NAME.getPrefix())) {
+            keywords = parseName(args).split("\\s");
+            AttributeContainsKeywordsPredicate type = new NameContainsKeywordsPredicate(Arrays.asList(keywords));
+            return new FindCommand(type);
+        } else if (args.contains(PREFIX_PHONE.getPrefix())) {
+            keywords = parsePhone(args).split("\\s");
+            AttributeContainsKeywordsPredicate type = new PhoneContainsKeywordsPredicate(Arrays.asList(keywords));
+            return new FindCommand(type);
+        } else if (args.contains(PREFIX_EMAIL.getPrefix())) {
+            keywords = parseEmail(args).split("\\s");
+            AttributeContainsKeywordsPredicate type = new EmailContainsKeywordsPredicate(Arrays.asList(keywords));
+            return new FindCommand(type);
+        } else if (args.contains(PREFIX_ACADEMIC_MAJOR.getPrefix())) {
+            keywords = parseAcademicMajor(args).split("\\s");
+            AttributeContainsKeywordsPredicate type =
+                    new AcademicMajorContainsKeywordsPredicate(Arrays.asList(keywords));
+            return new FindCommand(type);
+        } else {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
     }
 
+    /**
+     * Parses the given {@code String} of arguments into a {@code String name}
+     * which will be used for {@code FindCommandParser} object for execution.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the user input does not conform to {@code Name} format.
+     */
+    public String parseName(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME);
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        return name.fullName;
+    }
+
+    /**
+     * Parses the given {@code String} of arguments into a {@code String phone}
+     * which will be used for {@code FindCommandParser} object for execution.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the user input does not conform to {@code Phone} format.
+     */
+    public String parsePhone(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_PHONE);
+        if (!arePrefixesPresent(argMultimap, PREFIX_PHONE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
+        return phone.value;
+    }
+
+    /**
+     * Parses the given {@code String} of arguments into a {@code String email}
+     * which will be used for {@code FindCommandParser} object for execution.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the user input does not conform to {@code Email} format.
+     */
+    public String parseEmail(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_EMAIL);
+        if (!arePrefixesPresent(argMultimap, PREFIX_EMAIL)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
+        return email.value;
+    }
+
+    /**
+     * Parses the given {@code String} of arguments into a {@code String academicMajor}
+     * which will be used for {@code FindCommandParser} object for execution.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the user input does not conform to {@code AcademicMajor} format.
+     */
+    public String parseAcademicMajor(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_ACADEMIC_MAJOR);
+        if (!arePrefixesPresent(argMultimap, PREFIX_ACADEMIC_MAJOR)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+        AcademicMajor academicMajor = ParserUtil.parseAcademicMajor(argMultimap.getValue(PREFIX_ACADEMIC_MAJOR).get());
+        return academicMajor.value;
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 }
+

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -41,19 +41,19 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         String[] keywords;
         if (args.contains(PREFIX_NAME.getPrefix())) {
-            keywords = parseName(args).split("\\s");
+            keywords = parseName(args).split("\\s+");
             AttributeContainsKeywordsPredicate type = new NameContainsKeywordsPredicate(Arrays.asList(keywords));
             return new FindCommand(type);
         } else if (args.contains(PREFIX_PHONE.getPrefix())) {
-            keywords = parsePhone(args).split("\\s");
+            keywords = parsePhone(args).split("\\s+");
             AttributeContainsKeywordsPredicate type = new PhoneContainsKeywordsPredicate(Arrays.asList(keywords));
             return new FindCommand(type);
         } else if (args.contains(PREFIX_EMAIL.getPrefix())) {
-            keywords = parseEmail(args).split("\\s");
+            keywords = parseEmail(args).split("\\s+");
             AttributeContainsKeywordsPredicate type = new EmailContainsKeywordsPredicate(Arrays.asList(keywords));
             return new FindCommand(type);
         } else if (args.contains(PREFIX_ACADEMIC_MAJOR.getPrefix())) {
-            keywords = parseAcademicMajor(args).split("\\s");
+            keywords = parseAcademicMajor(args).split("\\s+");
             AttributeContainsKeywordsPredicate type =
                     new AcademicMajorContainsKeywordsPredicate(Arrays.asList(keywords));
             return new FindCommand(type);

--- a/src/main/java/seedu/address/model/person/AcademicMajorContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AcademicMajorContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Academic Major} matches any of the keywords given.
+ */
+public class AcademicMajorContainsKeywordsPredicate implements AttributeContainsKeywordsPredicate {
+    private final List<String> keywords;
+
+    public AcademicMajorContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword ->
+                        StringUtil.containsWordIgnoreCase(person.getAcademicMajor().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AcademicMajorContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((AcademicMajorContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/AttributeContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AttributeContainsKeywordsPredicate.java
@@ -1,0 +1,12 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s {@code Attributes} matches any of the keywords given.
+ */
+public interface AttributeContainsKeywordsPredicate extends Predicate<Person> {
+
+    boolean test(Person person);
+    boolean equals(Object other);
+}

--- a/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
@@ -1,0 +1,30 @@
+package seedu.address.model.person;
+
+import java.util.List;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Email} matches any of the keywords given.
+ */
+public class EmailContainsKeywordsPredicate implements AttributeContainsKeywordsPredicate {
+    private final List<String> keywords;
+
+    public EmailContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof EmailContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((EmailContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -1,14 +1,13 @@
 package seedu.address.model.person;
 
 import java.util.List;
-import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */
-public class NameContainsKeywordsPredicate implements Predicate<Person> {
+public class NameContainsKeywordsPredicate implements AttributeContainsKeywordsPredicate {
     private final List<String> keywords;
 
     public NameContainsKeywordsPredicate(List<String> keywords) {

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -1,0 +1,30 @@
+package seedu.address.model.person;
+
+import java.util.List;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ */
+public class PhoneContainsKeywordsPredicate implements AttributeContainsKeywordsPredicate {
+    private final List<String> keywords;
+
+    public PhoneContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PhoneContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((PhoneContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/tag/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/tag/TagContainsKeywordsPredicate.java
@@ -1,0 +1,38 @@
+package seedu.address.model.tag;
+
+import java.util.List;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.person.AttributeContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+
+/**
+ * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ */
+public class TagContainsKeywordsPredicate implements AttributeContainsKeywordsPredicate {
+    private final List<String> keywords;
+
+    public TagContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        for (Tag tag: person.getTags()) {
+            if (keywords.stream()
+                    .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(tag.tagName, keyword)) == true) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TagContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.AttributeContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
@@ -29,9 +30,9 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
+        AttributeContainsKeywordsPredicate firstPredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
+        AttributeContainsKeywordsPredicate secondPredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("second"));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
@@ -57,7 +58,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        AttributeContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -67,7 +68,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        AttributeContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -103,7 +104,7 @@ public class AddressBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+                FindCommand.COMMAND_WORD + " " + PREFIX_NAME + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.AttributeContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 public class FindCommandParserTest {
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -9,7 +9,9 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.person.AttributeContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 public class FindCommandParserTest {
 
@@ -23,12 +25,13 @@ public class FindCommandParserTest {
     @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        AttributeContainsKeywordsPredicate testName = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
+        FindCommand expectedFindCommand = new FindCommand(testName);
+        assertParseSuccess(parser, " " + PREFIX_NAME + "Alice Bob", expectedFindCommand);
 
+        // This one might not be too relevant in our case cause they need to enter a solid name for it
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        // assertParseSuccess(parser, " " + PREFIX_NAME + " \n Alice \n \t Bob  \t", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -28,10 +28,6 @@ public class FindCommandParserTest {
         AttributeContainsKeywordsPredicate testName = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
         FindCommand expectedFindCommand = new FindCommand(testName);
         assertParseSuccess(parser, " " + PREFIX_NAME + "Alice Bob", expectedFindCommand);
-
-        // This one might not be too relevant in our case cause they need to enter a solid name for it
-        // multiple whitespaces between keywords
-        // assertParseSuccess(parser, " " + PREFIX_NAME + " \n Alice \n \t Bob  \t", expectedFindCommand);
     }
 
 }


### PR DESCRIPTION
The initial FindCommand can only be used to find contacts through name. After this implementation,
it is able to find contacts using other Person's attributes such as phone or academicMajor.
The usage changes from find [Keywords] to find [Attribute's Prefix] [Keywords].