### PR TITLE
Implement viewcontact command to view student contact in an existing group

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,5 +9,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_NON_EXISTENT_GROUP = "This group does not exist in the list";
 
 }

--- a/src/main/java/seedu/address/logic/commands/DeassignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeassignCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.logic.commands.AssignCommand.MESSAGE_GROUP_DOES_NOT_EXIST;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 
 import java.util.List;
@@ -33,6 +32,8 @@ public class DeassignCommand extends Command {
     public static final String MESSAGE_PERSON_DOES_NOT_EXIST = "%1$s does not exist in %2$s.";
 
     public static final String MESSAGE_DEASSIGN_SUCCESS = "Student %1$s deassigned from %2$s";
+
+    public static final String MESSAGE_GROUP_DOES_NOT_EXIST = "This group does not exist in ArchDuke";
 
     private final Index index;
     private final Group group;

--- a/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
@@ -1,11 +1,68 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.group.Group;
 
+/**
+ * Views student contacts in the specific group in ArchDuke.
+ */
 public class ViewContactCommand extends Command {
+
+    public static final String COMMAND_WORD = "viewcontact";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Views student contacts in a specified group in ArchDuke. "
+            + "Parameters: "
+            + PREFIX_GROUP_NAME + "GROUP_NAME \n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_GROUP_NAME + "CS2103-W16-3";
+
+    public static final String MESSAGE_NON_EXISTENT_GROUP = "This group does not exist in the list";
+
+    public static final String MESSAGE_SUCCESS = "Here are the student contacts in this group: %s";
+
+    public static final String MESSAGE_ARGUMENTS = "View tasks in group: %s";
+
+    private final Group group;
+
+    /**
+     * Constructs a {@code ViewContactCommand} with the specified field.
+     *
+     * @param group The group in which the tasks would be viewed.
+     */
+    public ViewContactCommand(Group group) {
+        requireNonNull(group);
+
+        this.group = group;
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        return null;
+        if (model.hasGroup(group)) { //check whether the specified group exists
+            return new CommandResult(model.viewContact(group));
+        } else {
+            throw new CommandException(MESSAGE_NON_EXISTENT_GROUP);
+        }
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ViewContactCommand)) {
+            return false;
+        }
+
+        // state check
+        ViewContactCommand e = (ViewContactCommand) other;
+        return group.equals(e.group);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
@@ -1,0 +1,11 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+public class ViewContactCommand extends Command {
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        return null;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -21,7 +21,7 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new AddCommand object
+ * Parses input arguments and creates a new AddCommand object.
  */
 public class AddCommandParser implements Parser<AddCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddGroupCommandParser.java
@@ -11,6 +11,9 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.group.Group;
 import seedu.address.model.group.GroupName;
 
+/**
+ * Parses input arguments and creates a new AddGroupCommand object.
+ */
 public class AddGroupCommandParser implements Parser<AddGroupCommand> {
 
     /**

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ViewContactCommand;
 import seedu.address.logic.commands.ViewTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -95,6 +96,9 @@ public class AddressBookParser {
 
         case ViewTaskCommand.COMMAND_WORD:
             return new ViewTaskCommandParser().parse(arguments);
+
+        case ViewContactCommand.COMMAND_WORD:
+            return new ViewContactCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -7,7 +7,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
- * Parses input arguments and creates a new DeleteCommand object
+ * Parses input arguments and creates a new DeleteCommand object.
  */
 public class DeleteCommandParser implements Parser<DeleteCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -20,7 +20,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new EditCommand object
+ * Parses input arguments and creates a new EditCommand object.
  */
 public class EditCommandParser implements Parser<EditCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -19,7 +19,7 @@ import seedu.address.model.person.PhoneContainsKeywordsPredicate;
 import seedu.address.model.tag.TagContainsKeywordsPredicate;
 
 /**
- * Parses input arguments and creates a new FindCommand object
+ * Parses input arguments and creates a new FindCommand object.
  */
 public class FindCommandParser implements Parser<FindCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
@@ -1,2 +1,47 @@
-package seedu.address.logic.parser;public class ViewContactCommandParser {
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.ViewContactCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupName;
+
+/**
+ * Parses input arguments and creates a new ViewContactCommand object.
+ */
+public class ViewContactCommandParser implements Parser<ViewContactCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code ViewContactCommand}
+     * and returns an {@code ViewContactCommand} object for execution.
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    @Override
+    public ViewContactCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_GROUP_NAME);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_GROUP_NAME)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewContactCommand.MESSAGE_USAGE));
+        }
+
+        GroupName groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP_NAME).orElse(""));
+        Group group = new Group(groupName);
+
+        return new ViewContactCommand(group);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewContactCommandParser.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.parser;public class ViewContactCommandParser {
+}

--- a/src/main/java/seedu/address/logic/parser/ViewTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewTaskCommandParser.java
@@ -11,6 +11,9 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.group.Group;
 import seedu.address.model.group.GroupName;
 
+/**
+ * Parses input arguments and creates a new ViewTaskCommand object.
+ */
 public class ViewTaskCommandParser implements Parser<ViewTaskCommand> {
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -179,6 +179,14 @@ public class AddressBook implements ReadOnlyAddressBook {
         return groups.getGroup(g).viewTask();
     }
 
+    /**
+     * Views student contacts from a specified group from the address book.
+     * The group must already exist in the address book.
+     */
+    public String viewContact(Group g) {
+        return groups.getGroup(g).viewContact();
+    }
+
     //// util methods
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -122,6 +122,13 @@ public interface Model {
     String viewTask(Group group);
 
     /**
+     * Views the student contacts into the specified group.
+     * {@code group} must exists in the address book.
+     *
+     */
+    String viewContact(Group group);
+
+    /**
      * Replaces the given person {@code target} with {@code editedPerson}.
      * {@code target} must exist in the address book.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -134,6 +134,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public String viewContact(Group group) {
+        return addressBook.viewContact(group);
+    }
+
+    @Override
     public void addPerson(Person person) {
         addressBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -2,6 +2,7 @@ package seedu.address.model.group;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -67,7 +68,7 @@ public class Group {
     }
 
     public Set<Person> getPersons() {
-        return this.persons;
+        return Collections.unmodifiableSet(persons);
     }
 
     /**
@@ -109,11 +110,33 @@ public class Group {
     public String viewTask() {
         ObservableList<Task> taskList = tasks.asUnmodifiableObservableList();
         String output = "Here are the tasks in the group: \n";
-        for (int i = 0; i < taskList.size(); i++) {
-            output += (i + 1) + ". " + taskList.get(i).getTaskName().taskName + "\n";
+        for (int id = 0; id < taskList.size(); id++) {
+            output += (id + 1) + ". " + taskList.get(id).getTaskName().taskName + "\n";
         }
         return output;
     }
+
+    /**
+     * Views student contacts from this specific group.
+     */
+    public String viewContact() {
+        final StringBuilder builder = new StringBuilder();
+
+        String output = "Here are the student contacts in the group: \n";
+        builder.append(output);
+
+        Set<Person> persons = getPersons();
+        if (!persons.isEmpty()) {
+            int id = 1;
+
+            for (Person person : persons) {
+                builder.append(id).append(". ").append(person.getName()).append("\n");
+                id++;
+            }
+        }
+        return builder.toString();
+    }
+
 
     /**
      * Retrieves the UniqueTaskList from this specific group.

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -140,7 +140,6 @@ public class Group {
 
     /**
      * Retrieves the UniqueTaskList from this specific group.
-     *
      */
     public UniqueTaskList getTaskList() {
         return tasks;

--- a/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
@@ -1,16 +1,48 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.group.Group;
+import seedu.address.testutil.GroupBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for {@code AssignCommand}.
  */
 public class AssignCommandTest {
 
+    public static final String NON_EXISTENT_GROUP_NAME = "Invalid Group Name";
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
     @Test
     public void constructor_nullGroupPerson_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new AssignCommand(null, null));
+    }
+
+    @Test
+    public void constructor_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AssignCommand(null,
+                new GroupBuilder().build()));
+    }
+
+    @Test
+    public void constructor_nullGroup_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AssignCommand(Index.fromOneBased(1), null));
+    }
+
+    @Test
+    public void execute_invalidGroup_throwsCommandException() {
+        Group groupToAssign = new GroupBuilder().withGroupName(NON_EXISTENT_GROUP_NAME).build();
+        AssignCommand command = new AssignCommand(INDEX_FIRST_PERSON, groupToAssign);
+
+        assertCommandFailure(command, model, AssignCommand.MESSAGE_GROUP_DOES_NOT_EXIST);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -44,5 +45,15 @@ public class AssignCommandTest {
         AssignCommand command = new AssignCommand(INDEX_FIRST_PERSON, groupToAssign);
 
         assertCommandFailure(command, model, AssignCommand.MESSAGE_GROUP_DOES_NOT_EXIST);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Group groupToAssign = new GroupBuilder().build();
+
+        AssignCommand assignCommand = new AssignCommand(outOfBoundIndex, groupToAssign);
+
+        assertCommandFailure(assignCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeassignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeassignCommandTest.java
@@ -1,16 +1,26 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.group.Group;
 import seedu.address.testutil.GroupBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for {@code DeassignCommand}.
  */
 public class DeassignCommandTest {
+
+    public static final String NON_EXISTENT_GROUP_NAME = "Invalid Group Name";
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void constructor_nullGroupPerson_throwsNullPointerException() {
@@ -27,4 +37,13 @@ public class DeassignCommandTest {
     public void constructor_nullGroup_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new DeassignCommand(Index.fromOneBased(1), null));
     }
+
+    @Test
+    public void execute_invalidGroup_throwsCommandException() {
+        Group groupToDeassign = new GroupBuilder().withGroupName(NON_EXISTENT_GROUP_NAME).build();
+        AssignCommand command = new AssignCommand(INDEX_FIRST_PERSON, groupToDeassign);
+
+        assertCommandFailure(command, model, DeassignCommand.MESSAGE_GROUP_DOES_NOT_EXIST);
+    }
+
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
@@ -1,14 +1,62 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalGroups.getTypicalAddressBook;
 
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.group.Group;
+import seedu.address.testutil.GroupBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for {@code DeleteGroupCommand}.
  */
 public class DeleteGroupCommandTest {
+
+    public static final String NON_EXISTENT_GROUP_NAME = "Invalid Group Name";
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void constructor_nullGroup_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new DeleteGroupCommand(null));
+    }
+
+    @Test
+    public void execute_invalidGroup_throwsCommandException() {
+        Group groupToView = new GroupBuilder().withGroupName(NON_EXISTENT_GROUP_NAME).build();
+        ViewTaskCommand command = new ViewTaskCommand(groupToView);
+
+        assertCommandFailure(command, model, Messages.MESSAGE_NON_EXISTENT_GROUP);
+    }
+
+    @Test
+    public void equals() {
+        final DeleteGroupCommand standardCommand = new DeleteGroupCommand(new GroupBuilder()
+                .withGroupName(VALID_GROUP_NAME_NUS_FINTECH_SOCIETY).build());
+
+        // same value --> returns true
+        DeleteGroupCommand commandWithSameValues = new DeleteGroupCommand(new GroupBuilder()
+                .withGroupName(VALID_GROUP_NAME_NUS_FINTECH_SOCIETY).build());
+
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object --> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null --> return false
+        assertFalse(standardCommand.equals(null));
+
+        // different group -> returns false
+        assertFalse(standardCommand.equals(new DeleteGroupCommand(new GroupBuilder()
+                .withGroupName(VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY).build())));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
@@ -32,8 +32,8 @@ public class DeleteGroupCommandTest {
 
     @Test
     public void execute_invalidGroup_throwsCommandException() {
-        Group groupToView = new GroupBuilder().withGroupName(NON_EXISTENT_GROUP_NAME).build();
-        ViewTaskCommand command = new ViewTaskCommand(groupToView);
+        Group groupToDelete = new GroupBuilder().withGroupName(NON_EXISTENT_GROUP_NAME).build();
+        ViewTaskCommand command = new ViewTaskCommand(groupToDelete);
 
         assertCommandFailure(command, model, Messages.MESSAGE_NON_EXISTENT_GROUP);
     }

--- a/src/test/java/seedu/address/logic/commands/ViewContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewContactCommandTest.java
@@ -1,2 +1,62 @@
-package seedu.address.logic.commands;public class ViewContactCommandTest {
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.group.Group;
+import seedu.address.testutil.GroupBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code ViewContactCommand}.
+ */
+public class ViewContactCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    private final String NON_EXISTENT_GROUP_NAME = "Invalid Group Name";
+
+    @Test
+    public void constructor_nullGroup_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new ViewContactCommand(null));
+    }
+
+    @Test
+    public void execute_invalidGroup_throwsCommandException() {
+        Group groupToView = new GroupBuilder().withGroupName(NON_EXISTENT_GROUP_NAME).build();
+        ViewContactCommand command = new ViewContactCommand(groupToView);
+
+        assertCommandFailure(command, model, Messages.MESSAGE_NON_EXISTENT_GROUP);
+    }
+
+    @Test
+    public void equals() {
+        final ViewContactCommand standardCommand = new ViewContactCommand(new GroupBuilder()
+                .withGroupName(VALID_GROUP_NAME_NUS_FINTECH_SOCIETY).build());
+
+        // same value --> returns true
+        ViewContactCommand commandWithSameValues = new ViewContactCommand(new GroupBuilder()
+                .withGroupName(VALID_GROUP_NAME_NUS_FINTECH_SOCIETY).build());
+
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object --> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null --> return false
+        assertFalse(standardCommand.equals(null));
+
+        // different group -> returns false
+        assertFalse(standardCommand.equals(new ViewContactCommand(new GroupBuilder()
+                .withGroupName("NUS Data Science Society").build())));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/ViewContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewContactCommandTest.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.commands;public class ViewContactCommandTest {
+}

--- a/src/test/java/seedu/address/logic/commands/ViewContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewContactCommandTest.java
@@ -21,9 +21,8 @@ import seedu.address.testutil.GroupBuilder;
  */
 public class ViewContactCommandTest {
 
+    public static final String NON_EXISTENT_GROUP_NAME = "Invalid Group Name";
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-
-    private final String NON_EXISTENT_GROUP_NAME = "Invalid Group Name";
 
     @Test
     public void constructor_nullGroup_throwsNullPointerException() {

--- a/src/test/java/seedu/address/logic/commands/ViewTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewTaskCommandTest.java
@@ -2,10 +2,19 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.group.Group;
 import seedu.address.testutil.GroupBuilder;
 
 /**
@@ -13,19 +22,30 @@ import seedu.address.testutil.GroupBuilder;
  */
 public class ViewTaskCommandTest {
 
+    public static final String NON_EXISTENT_GROUP_NAME = "Invalid Group Name";
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
     @Test
     public void constructor_nullGroup_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new ViewTaskCommand(null));
     }
 
     @Test
+    public void execute_invalidGroup_throwsCommandException() {
+        Group groupToView = new GroupBuilder().withGroupName(NON_EXISTENT_GROUP_NAME).build();
+        ViewTaskCommand command = new ViewTaskCommand(groupToView);
+
+        assertCommandFailure(command, model, Messages.MESSAGE_NON_EXISTENT_GROUP);
+    }
+
+    @Test
     public void equals() {
         final ViewTaskCommand standardCommand = new ViewTaskCommand(new GroupBuilder()
-                .withGroupName("NUS Fintech Society").build());
+                .withGroupName(VALID_GROUP_NAME_NUS_FINTECH_SOCIETY).build());
 
         // same value --> returns true
         ViewTaskCommand commandWithSameValues = new ViewTaskCommand(new GroupBuilder()
-                .withGroupName("NUS Fintech Society").build());
+                .withGroupName(VALID_GROUP_NAME_NUS_FINTECH_SOCIETY).build());
 
         assertTrue(standardCommand.equals(commandWithSameValues));
 
@@ -37,6 +57,6 @@ public class ViewTaskCommandTest {
 
         // different group -> returns false
         assertFalse(standardCommand.equals(new ViewTaskCommand(new GroupBuilder()
-                .withGroupName("NUS Data Science Society").build())));
+                .withGroupName(VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY).build())));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ViewTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewTaskCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -11,6 +12,11 @@ import seedu.address.testutil.GroupBuilder;
  * Contains integration tests (interaction with the Model) and unit tests for {@code ViewTaskCommand}.
  */
 public class ViewTaskCommandTest {
+
+    @Test
+    public void constructor_nullGroup_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new ViewTaskCommand(null));
+    }
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -27,6 +27,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ViewContactCommand;
 import seedu.address.logic.commands.ViewTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.group.Group;
@@ -100,6 +101,13 @@ public class AddressBookParserTest {
         Group group = new GroupBuilder().build();
         ViewTaskCommand command = (ViewTaskCommand) parser.parseCommand(TaskUtil.getViewTaskCommand(group));
         assertEquals(new ViewTaskCommand(group), command);
+    }
+
+    @Test
+    public void parseCommand_viewContact() throws Exception {
+        Group group = new GroupBuilder().build();
+        ViewContactCommand command = (ViewContactCommand) parser.parseCommand(GroupUtil.getViewContactCommand(group));
+        assertEquals(new ViewContactCommand(group), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ViewContactCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewContactCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ViewContactCommand;
+import seedu.address.testutil.GroupBuilder;
+
+public class ViewContactCommandParserTest {
+    private ViewContactCommandParser parser = new ViewContactCommandParser();
+    private final String nonEmptyGroupName = "NUS Fintech Society";
+
+    @Test
+    public void parse_groupSpecified_success() {
+        // have group name
+        String userInput = " " + PREFIX_GROUP_NAME + nonEmptyGroupName;
+        ViewContactCommand expectedCommand = new ViewContactCommand(new GroupBuilder().build());
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingCompulsoryField_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewContactCommand.MESSAGE_USAGE);
+
+        // no group name
+        assertParseFailure(parser, ViewContactCommand.COMMAND_WORD, expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/testutil/GroupUtil.java
+++ b/src/test/java/seedu/address/testutil/GroupUtil.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 import seedu.address.logic.commands.AddGroupCommand;
 import seedu.address.logic.commands.DeleteGroupCommand;
 import seedu.address.logic.commands.ViewContactCommand;
-import seedu.address.logic.commands.ViewTaskCommand;
 import seedu.address.model.group.Group;
 
 public class GroupUtil {

--- a/src/test/java/seedu/address/testutil/GroupUtil.java
+++ b/src/test/java/seedu/address/testutil/GroupUtil.java
@@ -4,6 +4,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 
 import seedu.address.logic.commands.AddGroupCommand;
 import seedu.address.logic.commands.DeleteGroupCommand;
+import seedu.address.logic.commands.ViewContactCommand;
+import seedu.address.logic.commands.ViewTaskCommand;
 import seedu.address.model.group.Group;
 
 public class GroupUtil {
@@ -16,7 +18,7 @@ public class GroupUtil {
     }
 
     /**
-     * Returns an delgroup command string for adding the {@code group}.
+     * Returns a delgroup command string for adding the {@code group}.
      */
     public static String getDeleteGroupCommand(Group group) {
         return DeleteGroupCommand.COMMAND_WORD + " " + getGroupDetails(group);
@@ -29,5 +31,12 @@ public class GroupUtil {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX_GROUP_NAME + group.getGroupName().groupName + " ");
         return sb.toString();
+    }
+
+    /**
+     * Returns a view contact command string for viewing student contacts the {@code group}.
+     */
+    public static String getViewContactCommand(Group group) {
+        return ViewContactCommand.COMMAND_WORD + " " + getGroupDetails(group);
     }
 }

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -112,6 +112,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public String viewContact(Group group) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public ObservableList<Person> getFilteredPersonList() {
         throw new AssertionError("This method should not be called.");
     }

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,8 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+
+    public static final Index INDEX_FIRST_GROUP = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_GROUP = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_GROUP = Index.fromOneBased(3);
 }


### PR DESCRIPTION
Command format: `viewcontact g/GROUP_NAME`

Summary of Implementation: 
* View student contacts in the specified group. Result displays on the result display.

I have checked that:
* `viewcontact` input throws the correct error message
* `viewcontact g/` throws the correct error message
* user input with non-existent `GROUP_NAME` throws the correct error message

I have attempted to: 
* write unit tests for directly and indirectly related methods 
