### PR TITLE
Fix delete command bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
@@ -69,6 +69,6 @@ public class AddTaskCommand extends Command {
 
         // state check
         AddTaskCommand e = (AddTaskCommand) other;
-        return taskToAdd.equals(e.taskToAdd);
+        return taskToAdd.equals(e.taskToAdd) && specificGroup.equals(e.specificGroup);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -8,6 +8,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.Person;
 
 /**
@@ -41,6 +42,13 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
+
+        for (Group group : model.getFilteredGroupList()) {
+            if (group.personExists(personToDelete)) {
+                model.deassignPerson(personToDelete, group);
+            }
+        }
+
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
@@ -1,2 +1,72 @@
-package seedu.address.logic.commands;public class AddTaskCommandTest {
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.group.Group;
+import seedu.address.model.task.Task;
+import seedu.address.testutil.GroupBuilder;
+import seedu.address.testutil.TaskBuilder;
+
+public class AddTaskCommandTest {
+
+    public static final String NON_EXISTENT_GROUP_NAME = "Invalid Group Name";
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void constructor_nullTaskGroup_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddTaskCommand(null, null));
+    }
+
+    @Test
+    public void constructor_nullTask_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddTaskCommand(null, new GroupBuilder().build()));
+    }
+
+    @Test
+    public void constructor_nullGroup_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddTaskCommand(new TaskBuilder().build(), null));
+    }
+
+    @Test
+    public void execute_invalidGroup_throwsCommandException() {
+        Group groupToAssign = new GroupBuilder().withGroupName(NON_EXISTENT_GROUP_NAME).build();
+        AddTaskCommand command = new AddTaskCommand(new TaskBuilder().build(), groupToAssign);
+
+        assertCommandFailure(command, model, AddTaskCommand.MESSAGE_NON_EXISTENT_GROUP);
+    }
+
+    @Test
+    public void equals() {
+        Group nusFintechSociety = new GroupBuilder().withGroupName("Nus Fintech Society").build();
+        Group nusDataScienceSociety = new GroupBuilder().withGroupName("Nus Data Science Society").build();
+        Task taskToAdd = new TaskBuilder().build();
+
+        AddTaskCommand addTaskToNusFintechSocietyCommand = new AddTaskCommand(taskToAdd, nusFintechSociety);
+        AddTaskCommand addTaskToNusDataScienceSocietyCommand = new AddTaskCommand(taskToAdd, nusDataScienceSociety);
+
+        // same object -> returns true
+        assertTrue(addTaskToNusFintechSocietyCommand.equals(addTaskToNusFintechSocietyCommand));
+
+        // same values -> returns true
+        AddTaskCommand addTaskToNusFintechSocietyCommandCopy = new AddTaskCommand(taskToAdd, nusFintechSociety);
+        assertTrue(addTaskToNusFintechSocietyCommand.equals(addTaskToNusFintechSocietyCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addTaskToNusFintechSocietyCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addTaskToNusFintechSocietyCommand.equals(null));
+
+        // different group -> returns false
+        assertFalse(addTaskToNusFintechSocietyCommand.equals(addTaskToNusDataScienceSocietyCommand));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
@@ -1,0 +1,2 @@
+package seedu.address.logic.commands;public class AddTaskCommandTest {
+}

--- a/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
@@ -1,34 +1,22 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_GROUP;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_GROUP;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
-
-import java.util.ArrayList;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.group.Group;
-import seedu.address.model.person.Person;
 import seedu.address.testutil.GroupBuilder;
-import seedu.address.testutil.ModelStub;
-import seedu.address.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for {@code AssignCommand}.

--- a/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignCommandTest.java
@@ -1,19 +1,34 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_GROUP;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_GROUP;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.ArrayList;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.group.Group;
+import seedu.address.model.person.Person;
 import seedu.address.testutil.GroupBuilder;
+import seedu.address.testutil.ModelStub;
+import seedu.address.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for {@code AssignCommand}.
@@ -55,5 +70,30 @@ public class AssignCommandTest {
         AssignCommand assignCommand = new AssignCommand(outOfBoundIndex, groupToAssign);
 
         assertCommandFailure(assignCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        Group nusFintechSociety = new GroupBuilder().withGroupName("Nus Fintech Society").build();
+        Group nusDataScienceSociety = new GroupBuilder().withGroupName("Nus Data Science Society").build();
+
+        AssignCommand assignFirstCommand = new AssignCommand(INDEX_FIRST_PERSON, nusFintechSociety);
+        AssignCommand assignSecondCommand = new AssignCommand(INDEX_SECOND_PERSON, nusDataScienceSociety);
+
+        // same object -> returns true
+        assertTrue(assignFirstCommand.equals(assignFirstCommand));
+
+        // same values -> returns true
+        AssignCommand assignFirstCommandCopy = new AssignCommand(INDEX_FIRST_PERSON, nusFintechSociety);
+        assertTrue(assignFirstCommand.equals(assignFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(assignFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(assignFirstCommand.equals(null));
+
+        // different group -> returns false
+        assertFalse(assignFirstCommand.equals(assignSecondCommand));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeassignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeassignCommandTest.java
@@ -1,12 +1,16 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -46,4 +50,38 @@ public class DeassignCommandTest {
         assertCommandFailure(command, model, DeassignCommand.MESSAGE_GROUP_DOES_NOT_EXIST);
     }
 
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Group groupToDeassign = new GroupBuilder().build();
+
+        DeassignCommand deassignCommand = new DeassignCommand(outOfBoundIndex, groupToDeassign);
+
+        assertCommandFailure(deassignCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        Group nusFintechSociety = new GroupBuilder().withGroupName("Nus Fintech Society").build();
+        Group nusDataScienceSociety = new GroupBuilder().withGroupName("Nus Data Science Society").build();
+
+        DeassignCommand deassignFirstCommand = new DeassignCommand(INDEX_FIRST_PERSON, nusFintechSociety);
+        DeassignCommand deassignSecondCommand = new DeassignCommand(INDEX_SECOND_PERSON, nusDataScienceSociety);
+
+        // same object -> returns true
+        assertTrue(deassignFirstCommand.equals(deassignFirstCommand));
+
+        // same values -> returns true
+        DeassignCommand deassignFirstCommandCopy = new DeassignCommand(INDEX_FIRST_PERSON, nusFintechSociety);
+        assertTrue(deassignFirstCommand.equals(deassignFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deassignFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deassignFirstCommand.equals(null));
+
+        // different group -> returns false
+        assertFalse(deassignFirstCommand.equals(deassignSecondCommand));
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
@@ -6,22 +6,17 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalGroups.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_GROUP;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
-import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.group.Group;
-import seedu.address.model.person.Person;
 import seedu.address.testutil.GroupBuilder;
 
 /**

--- a/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
@@ -5,16 +5,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalGroups.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_GROUP;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.group.Group;
+import seedu.address.model.person.Person;
 import seedu.address.testutil.GroupBuilder;
 
 /**
@@ -28,6 +35,19 @@ public class DeleteGroupCommandTest {
     @Test
     public void constructor_nullGroup_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new DeleteGroupCommand(null));
+    }
+
+    @Test
+    public void execute_validGroupUnfilteredList_success() {
+        Group groupToDelete = model.getFilteredGroupList().get(INDEX_FIRST_GROUP.getZeroBased());
+        DeleteGroupCommand deleteGroupCommand = new DeleteGroupCommand(groupToDelete);
+
+        String expectedMessage = String.format(DeleteGroupCommand.MESSAGE_DELETE_GROUP_SUCCESS, groupToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteGroup(groupToDelete);
+
+        assertCommandSuccess(deleteGroupCommand, model, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
@@ -1,0 +1,95 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.group.Group;
+import seedu.address.model.task.Task;
+import seedu.address.testutil.GroupBuilder;
+import seedu.address.testutil.TaskBuilder;
+
+public class DeleteTaskCommandTest {
+    public static final String NON_EXISTENT_GROUP_NAME = "Invalid Group Name";
+    public static final String NON_EXISTENT_TASK_NAME = "Invalid Task Name";
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void constructor_nullTaskGroup_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new DeleteTaskCommand(null, null));
+    }
+
+    @Test
+    public void constructor_nullTask_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new DeleteTaskCommand(null, new GroupBuilder().build()));
+    }
+
+    @Test
+    public void constructor_nullGroup_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new DeleteTaskCommand(new TaskBuilder().build(), null));
+    }
+
+    @Test
+    public void execute_invalidGroup_throwsCommandException() {
+        Group groupToDeleteTask = new GroupBuilder().withGroupName(NON_EXISTENT_GROUP_NAME).build();
+        DeleteTaskCommand command = new DeleteTaskCommand(new TaskBuilder().build(), groupToDeleteTask);
+
+        assertCommandFailure(command, model, DeleteTaskCommand.MESSAGE_NON_EXISTENT_GROUP);
+    }
+
+    @Test
+    public void execute_invalidTask_throwsCommandException() {
+        Group groupToDeleteTask = new GroupBuilder().build();
+        Task invalidTask = new TaskBuilder().withTaskName(NON_EXISTENT_TASK_NAME).build();
+
+        DeleteTaskCommand command = new DeleteTaskCommand(invalidTask, groupToDeleteTask);
+
+        assertCommandFailure(command, model, DeleteTaskCommand.MESSAGE_NON_EXISTENT_GROUP);
+    }
+
+    @Test
+    public void execute_invalidTaskGroup_throwsCommandException() {
+        Group groupToDeleteTask = new GroupBuilder().withGroupName(NON_EXISTENT_GROUP_NAME).build();
+        Task invalidTask = new TaskBuilder().withTaskName(NON_EXISTENT_TASK_NAME).build();
+
+        DeleteTaskCommand command = new DeleteTaskCommand(invalidTask, groupToDeleteTask);
+
+        assertCommandFailure(command, model, DeleteTaskCommand.MESSAGE_NON_EXISTENT_GROUP);
+    }
+
+    @Test
+    public void equals() {
+        Group nusFintechSociety = new GroupBuilder().withGroupName("Nus Fintech Society").build();
+        Group nusDataScienceSociety = new GroupBuilder().withGroupName("Nus Data Science Society").build();
+        Task taskToAdd = new TaskBuilder().build();
+
+        DeleteTaskCommand deleteTaskFromNusFintechSocietyCommand = new DeleteTaskCommand(taskToAdd, nusFintechSociety);
+        DeleteTaskCommand deleteTaskFromNusDataScienceSocietyCommand =
+                new DeleteTaskCommand(taskToAdd, nusDataScienceSociety);
+
+        // same object -> returns true
+        assertTrue(deleteTaskFromNusFintechSocietyCommand.equals(deleteTaskFromNusFintechSocietyCommand));
+
+        // same values -> returns true
+        DeleteTaskCommand deleteTaskFromNusFintechSocietyCommandCopy =
+                new DeleteTaskCommand(taskToAdd, nusFintechSociety);
+        assertTrue(deleteTaskFromNusFintechSocietyCommand.equals(deleteTaskFromNusFintechSocietyCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteTaskFromNusFintechSocietyCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteTaskFromNusFintechSocietyCommand.equals(null));
+
+        // different group -> returns false
+        assertFalse(deleteTaskFromNusFintechSocietyCommand.equals(deleteTaskFromNusDataScienceSocietyCommand));
+    }
+}


### PR DESCRIPTION
Summary of changes:
* Initially when deleting a student contact from the contact list, the student will still exist in the group that he was previously assigned to
* In this implementation, if a student were to be deleted, he would also be deleted from all existing groups
* This means that the group will no longer have the particular student as a member
* This also means that to have a student in a group, the student contact must already exist in the student contact list

Test:
* I have written some unit tests to try to increase code coverage. During the process a bug related to `addtask` command is found

Bug:
* The `equal()` method in `addtask` command was implemented wrongly and didn't check whether the task is assigned to the same group. This bug has been solved.