### PR TITLE
Fix bug for showing of task on the GUI

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 
@@ -37,6 +38,8 @@ public class AddGroupCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
         if (model.hasGroup(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_GROUP);
         }

--- a/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
@@ -48,11 +48,28 @@ public class AddTaskCommand extends Command {
             if (model.hasTask(taskToAdd, specificGroup)) {
                 throw new CommandException(MESSAGE_DUPLICATE_TASK);
             }
-            model.addTask(taskToAdd, specificGroup);
+
+            Group groupToAddTask = specificGroup;
+            Group groupAddedTask = createAddedTaskGroup(groupToAddTask, taskToAdd, model);
+
+            model.setGroup(specificGroup, groupAddedTask);
+
             return new CommandResult(String.format(MESSAGE_SUCCESS, taskToAdd));
         } else {
             throw new CommandException(MESSAGE_NON_EXISTENT_GROUP);
         }
+    }
+
+    /**
+     * Creates and returns a {@code Group} with the details of {@code groupToAddTask}
+     */
+    private static Group createAddedTaskGroup(Group groupToAddTask, Task taskToAdd, Model model) {
+        assert groupToAddTask != null;
+
+        model.addTask(taskToAdd, groupToAddTask);
+        Group groupAddedTask = model.getGroup(groupToAddTask);
+
+        return groupAddedTask;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -56,11 +56,28 @@ public class DeleteTaskCommand extends Command {
             if (!model.hasTask(task, group)) {
                 throw new CommandException(MESSAGE_NON_EXISTENT_TASK);
             }
-            model.deleteTask(task, group);
+
+            Group groupToDeleteTask = group;
+            Group groupDeletedTask = createDeletedTaskGroup(groupToDeleteTask, task, model);
+
+            model.setGroup(group, groupDeletedTask);
+
             return new CommandResult(String.format(MESSAGE_DELETE_TASK_SUCCESS, task));
         } else {
             throw new CommandException(MESSAGE_NON_EXISTENT_GROUP);
         }
+    }
+
+    /**
+     * Creates and returns a {@code Group} with the details of {@code groupToDeleteTask}
+     */
+    private static Group createDeletedTaskGroup(Group groupToDeleteTask, Task taskToDelete, Model model) {
+        assert groupToDeleteTask != null;
+
+        model.deleteTask(taskToDelete, groupToDeleteTask);
+        Group groupDeletedTask = model.getGroup(groupToDeleteTask);
+
+        return groupDeletedTask;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -143,6 +143,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * The group identity of {@code editedGroup} must not be the same as another existing group in the address book.
      */
     public void setGroup(Group target, Group editedGroup) {
+        requireNonNull(editedGroup);
         groups.setGroup(target, editedGroup);
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -135,6 +135,13 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
+    /**
+     * Replaces the given group {@code target} with {@code editedGroup}.
+     * {@code target} must exist in the address book.
+     * The group identity of {@code editedGroup} must not be the same as another existing group in the address book.
+     */
+    void setGroup(Group target, Group editedGroup);
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
@@ -167,6 +174,12 @@ public interface Model {
      * {@code Group} must already exist in the address book.
      */
     void deassignPerson(Person person, Group group);
+
+    /**
+     * Gets a group from the filtered group list.
+     * {@code Group} must already exist in the address book.
+     */
+    public Group getGroup(Group groupToGet);
 
     /**
      * Updates the filter of the filtered group list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.group.Group;
+import seedu.address.model.group.exceptions.GroupNotFoundException;
 import seedu.address.model.person.Person;
 import seedu.address.model.task.Task;
 
@@ -163,6 +164,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void setGroup(Group target, Group editedGroup) {
+        requireAllNonNull(target, editedGroup);
+        addressBook.setGroup(target, editedGroup);
+    }
+
+    @Override
     public void assignPerson(Person person, Group group) {
         addressBook.assignPerson(person, group);
     }
@@ -170,6 +177,23 @@ public class ModelManager implements Model {
     @Override
     public void deassignPerson(Person person, Group group) {
         addressBook.deassignPerson(person, group);
+    }
+
+    @Override
+    public Group getGroup(Group groupToGet) {
+        requireNonNull(groupToGet);
+
+        try {
+            for (int i = 0; i < filteredGroups.size(); i++) {
+                System.out.println(filteredGroups.get(i));
+                if (filteredGroups.get(i).equals(groupToGet)) {
+                    return filteredGroups.get(i);
+                }
+            }
+        } catch (GroupNotFoundException e) {
+            System.out.println("Group is not found in the list.");
+        }
+        return null;
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/ui/GroupCard.java
+++ b/src/main/java/seedu/address/ui/GroupCard.java
@@ -1,7 +1,10 @@
 package seedu.address.ui;
 
+import java.util.Comparator;
+
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.group.Group;
@@ -21,6 +24,12 @@ public class GroupCard extends UiPart<Region> {
     private Label groupName;
     @FXML
     private Label id;
+    @FXML
+    private FlowPane taskName;
+    @FXML
+    private Label taskId;
+    @FXML
+    private Label taskTitle;
 
     /**
      * Creates a {@code GroupCode} with the given {@code Group} and index to display.
@@ -30,6 +39,11 @@ public class GroupCard extends UiPart<Region> {
         this.group = group;
         id.setText(displayedIndex + ". ");
         groupName.setText(group.getGroupName().groupName);
+        taskTitle.setText("Task List:");
+
+        group.getTaskList().getInternalList().stream()
+                .sorted(Comparator.comparing(task -> task.taskName.taskName))
+                .forEach(task -> taskName.getChildren().add(new Label(task.taskName.taskName)));
     }
 
     @Override

--- a/src/main/resources/view/GroupListCard.fxml
+++ b/src/main/resources/view/GroupListCard.fxml
@@ -25,7 +25,25 @@
                         <Region fx:constant="USE_PREF_SIZE" />
                     </minWidth>
                 </Label>
-                <Label fx:id="groupName" text="\$first" styleClass="cell_big_label" />
+                <Label fx:id="groupName" text="\$first" styleClass="cell_big_label" style="-fx-font-size: 18px; -fx-font-weight: bold;"/>
+            </HBox>
+            <HBox spacing="5" alignment="CENTER_LEFT">
+                <padding>
+                    <Insets top="20" right="5" bottom="5" left="15" />
+                </padding>
+                <Label fx:id="taskTitle" text="\$first" styleClass="cell_big_label" style="-fx-font-size: 16px; -fx-font-weight: 900; "/>
+            </HBox>
+            <HBox>
+                <padding>
+                    <Insets top="10" right="5" bottom="20" left="15" />
+                </padding>
+                <Label fx:id="taskId" styleClass="cell_big_label" style="-fx-font-size: 14px;">
+                    <minWidth>
+                        <!-- Ensures that the label text is never truncated -->
+                        <Region fx:constant="USE_PREF_SIZE" />
+                    </minWidth>
+                </Label>
+                <FlowPane fx:id="taskName" orientation="vertical" maxHeight="200" vgap="10" style="-fx-font-size: 14px; "/>
             </HBox>
         </VBox>
     </GridPane>

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TASK;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -41,6 +42,8 @@ public class CommandTestUtil {
     public static final String VALID_GROUP_NAME_NUS_FINTECH_SOCIETY = "NUS Fintech Society";
     public static final String VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY = "NUS Data Science Society";
 
+    public static final String VALID_TASK_NAME_NUS_FINTECH_SOCIETY = "Meeting";
+
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
@@ -56,6 +59,8 @@ public class CommandTestUtil {
             + VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
     public static final String GROUP_DESC_NUS_DATA_SCIENCE_SOCIETY = " " + PREFIX_GROUP_NAME
             + VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY;
+
+    public static final String TASK_DESC_NUS_FINTECH_SOCIETY = " " + PREFIX_TASK + VALID_TASK_NAME_NUS_FINTECH_SOCIETY;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -17,7 +17,9 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddGroupCommand;
 import seedu.address.logic.commands.AddTaskCommand;
+import seedu.address.logic.commands.AssignCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeassignCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteGroupCommand;
 import seedu.address.logic.commands.DeleteTaskCommand;
@@ -101,6 +103,26 @@ public class AddressBookParserTest {
         Group group = new GroupBuilder().build();
         ViewTaskCommand command = (ViewTaskCommand) parser.parseCommand(TaskUtil.getViewTaskCommand(group));
         assertEquals(new ViewTaskCommand(group), command);
+    }
+
+    @Test
+    public void parseCommand_assign() throws Exception {
+        Group group = new GroupBuilder().build();
+        AssignCommand command = (AssignCommand) parser.parseCommand(
+            AssignCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
+                    + " " + GroupUtil.getGroupDetails(group)
+        );
+        assertEquals(new AssignCommand(INDEX_FIRST_PERSON, group), command);
+    }
+
+    @Test
+    public void parseCommand_deassign() throws Exception {
+        Group group = new GroupBuilder().build();
+        DeassignCommand command = (DeassignCommand) parser.parseCommand(
+                DeassignCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased()
+                        + " " + GroupUtil.getGroupDetails(group)
+        );
+        assertEquals(new DeassignCommand(INDEX_FIRST_PERSON, group), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AssignCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AssignCommandParserTest.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.GROUP_DESC_NUS_FINTECH_SOCIETY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AssignCommand;
+import seedu.address.model.group.Group;
+import seedu.address.testutil.GroupBuilder;
+
+public class AssignCommandParserTest {
+    private AssignCommandParser parser = new AssignCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+
+        Group expectedGroup = new GroupBuilder().withGroupName(VALID_GROUP_NAME_NUS_FINTECH_SOCIETY).build();
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + 1
+                + GROUP_DESC_NUS_FINTECH_SOCIETY, new AssignCommand(INDEX_FIRST_PERSON, expectedGroup));
+
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignCommand.MESSAGE_USAGE);
+
+        // missing group name prefix
+        assertParseFailure(parser, 1 + VALID_GROUP_NAME_NUS_FINTECH_SOCIETY,
+                expectedMessage);
+
+        // missing index
+        assertParseFailure(parser, GROUP_DESC_NUS_FINTECH_SOCIETY,
+                expectedMessage);
+        // missing group name
+        assertParseFailure(parser, String.valueOf(1),
+                expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, 1 + VALID_GROUP_NAME_NUS_FINTECH_SOCIETY,
+                expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -107,6 +107,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public void setGroup(Group target, Group editedGroup) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public String viewTask(Group group) {
         throw new AssertionError("This method should not be called.");
     }
@@ -153,6 +158,11 @@ public class ModelStub implements Model {
 
     @Override
     public void deassignPerson(Person personToDeassign, Group group) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Group getGroup(Group groupToGet) {
         throw new AssertionError("This method should not be called.");
     }
 }


### PR DESCRIPTION
Fix the GUI issue to be able to "see" the execution of `addtask` and `deltask` commands

Manage to solve with the help from this issue: https://github.com/nus-cs2103-AY2122S2/forum/issues/217 😄

In summary:

For any gui updates, the `ObservableList<Group>` methods such as `set`, `add`, `setAll` etc should be called. 

Previously, I was just simply getting the `Group` object and mutating it by adding a `task`.  This eventually just call the `addTask(Task task)` method in `Group` to add the task to the group in the `UniqueGroupList`. 

This change will not be "seen" by the `ObservableList` as the `UniqueGroupList` is not being changed. (Yes, indeed I'm not changing the group but I was only chaing the `UnqueTaskList`!)

I should instead do something similar to how a Person is modified, ie Create a copy of the Group, add a task to the copy, then set the "old" group object with the "new" group object.

In this implementation I did the following:
* Intentionally modify the group object once the task is being added
* Set the original object to this newly modified group object
* Call the `setGroup(Group target, Group editedGroup)` to update the original group to this newly added group. This update the groups in the `ObservableList<Group>` and "alert" the GUI of the changes.