### PR TITLE
Fix GUI for extreme case

### DIFF
--- a/src/main/resources/view/GroupListCard.fxml
+++ b/src/main/resources/view/GroupListCard.fxml
@@ -9,6 +9,7 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.control.ScrollPane?>
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane HBox.hgrow="ALWAYS">
         <columnConstraints>
@@ -25,7 +26,7 @@
                         <Region fx:constant="USE_PREF_SIZE" />
                     </minWidth>
                 </Label>
-                <Label fx:id="groupName" text="\$first" styleClass="cell_big_label" style="-fx-font-size: 18px; -fx-font-weight: bold;"/>
+                <Label fx:id="groupName" text="\$first" styleClass="cell_big_label" style="-fx-font-size: 18px; -fx-font-weight: bold;" wrapText="true" />
             </HBox>
             <HBox spacing="5" alignment="CENTER_LEFT">
                 <padding>
@@ -55,7 +56,9 @@
                         <Region fx:constant="USE_PREF_SIZE" />
                     </minWidth>
                 </Label>
-                <FlowPane fx:id="taskName" orientation="vertical" maxHeight="200" vgap="10" style="-fx-font-size: 14px; "/>
+                <ScrollPane fx:id="taskContainer" fitToWidth="true"  prefWidth="600" prefViewportHeight="100">
+                    <FlowPane fx:id="taskName" orientation="vertical"  vgap="10" style="-fx-font-size: 14px; "/>
+                </ScrollPane>
             </HBox>
         </VBox>
     </GridPane>

--- a/src/main/resources/view/LightTheme.css
+++ b/src/main/resources/view/LightTheme.css
@@ -381,3 +381,16 @@
     -fx-text-fill: #17083E;
     -fx-padding: 4 20 4 20;
 }
+
+.list-cell:filled:selected #taskContainer {
+    -fx-border-color: #3e7b91;
+    -fx-border-width: 0;
+}
+
+.scroll-pane > .viewport {
+   -fx-background-color: transparent;
+}
+
+.scroll-pane {
+   -fx-background-color: transparent;
+}

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -24,7 +24,7 @@
         <URL value="@Extensions.css" />
       </stylesheets>
 
-      <VBox>
+      <VBox VBox.vgrow="ALWAYS">
         <MenuBar fx:id="menuBar" style="-fx-background-color: e6ecf0;" VBox.vgrow="NEVER">
           <Menu mnemonicParsing="false" text="File">
             <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -19,18 +19,18 @@
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
       <HBox spacing="5" alignment="CENTER_LEFT">
-        <Label fx:id="id" styleClass="cell_big_label">
+        <Label fx:id="id" styleClass="cell_big_label" wrapText="true">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true"/>
       </HBox>
       <FlowPane fx:id="tags" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="academicMajor" styleClass="cell_small_label" text="\$academicMajor" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" wrapText="true"/>
+      <Label fx:id="academicMajor" styleClass="cell_small_label" text="\$academicMajor" wrapText="true"/>
+      <Label fx:id="email" styleClass="cell_small_label" text="\$email" wrapText="true"/>
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
* Add scrollpane to support long task list
* Add horizontal scrollpane to support long task name
* Wrap text for student contact attributes and group name to support extreme long attributes

Note:
I think aesthetic is compromised here, unfortunately. But I'm worried that without all these, it might be reported as bug. This is the best I can do for now.