### PR TITLE
Modify case insensitivity for group and task

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -36,7 +36,7 @@ import seedu.address.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(0, 2, 0, true);
+    public static final Version VERSION = new Version(1, 3, 0, true);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -83,7 +83,7 @@ public class Group {
         }
 
         return otherGroup != null
-                && otherGroup.getGroupName().equals(getGroupName());
+                && otherGroup.getGroupName().toString().equalsIgnoreCase(getGroupName().toString());
     }
 
     /**
@@ -173,7 +173,7 @@ public class Group {
         }
 
         Group otherGroup = (Group) other;
-        return otherGroup.getGroupName().equals(getGroupName());
+        return otherGroup.getGroupName().toString().equalsIgnoreCase(getGroupName().toString());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/group/GroupName.java
+++ b/src/main/java/seedu/address/model/group/GroupName.java
@@ -68,6 +68,6 @@ public class GroupName {
 
         // state check
         GroupName e = (GroupName) other;
-        return groupName.equals(e.groupName);
+        return groupName.equalsIgnoreCase(e.groupName);
     }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -70,7 +70,7 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPerson.getName().toString().equalsIgnoreCase(getName().toString());
     }
 
     /**
@@ -88,7 +88,7 @@ public class Person {
         }
 
         Person otherPerson = (Person) other;
-        return otherPerson.getName().equals(getName())
+        return otherPerson.getName().toString().equalsIgnoreCase(getName().toString())
                 && otherPerson.getPhone().equals(getPhone())
                 && otherPerson.getEmail().equals(getEmail())
                 && otherPerson.getAcademicMajor().equals(getAcademicMajor())

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -34,7 +34,7 @@ public class Task {
         }
 
         return otherTask != null
-                && otherTask.getTaskName().equals(getTaskName());
+                && otherTask.getTaskName().toString().equalsIgnoreCase(getTaskName().toString());
     }
 
 
@@ -58,7 +58,7 @@ public class Task {
         }
 
         Task otherTask = (Task) other;
-        return otherTask.getTaskName().equals(getTaskName());
+        return otherTask.getTaskName().toString().equalsIgnoreCase(getTaskName().toString());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -72,7 +72,6 @@ public class Task {
      *
      * @return String representation of a task.
      */
-
     @Override
     public String toString() {
         return String.valueOf(taskName.getTaskName());

--- a/src/main/java/seedu/address/model/task/TaskName.java
+++ b/src/main/java/seedu/address/model/task/TaskName.java
@@ -65,12 +65,12 @@ public class TaskName {
         }
 
         // instanceof handles null
-        if (!(other instanceof seedu.address.model.task.TaskName)) {
+        if (!(other instanceof TaskName)) {
             return false;
         }
 
         // state check
-        seedu.address.model.task.TaskName e = (seedu.address.model.task.TaskName) other;
+        TaskName e = (TaskName) other;
         return taskName.equals(e.taskName);
     }
 }

--- a/src/main/java/seedu/address/model/task/TaskName.java
+++ b/src/main/java/seedu/address/model/task/TaskName.java
@@ -71,6 +71,6 @@ public class TaskName {
 
         // state check
         TaskName e = (TaskName) other;
-        return taskName.equals(e.taskName);
+        return taskName.equalsIgnoreCase(e.taskName);
     }
 }

--- a/src/test/java/seedu/address/model/group/GroupNameTest.java
+++ b/src/test/java/seedu/address/model/group/GroupNameTest.java
@@ -1,10 +1,15 @@
 package seedu.address.model.group;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalGroups.NUS_FINTECH_SOCIETY;
 
 import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.GroupBuilder;
 
 public class GroupNameTest {
     @Test
@@ -35,5 +40,17 @@ public class GroupNameTest {
         assertTrue(GroupName.isValidGroupName("NUS Statistics and Data Science Society")); // long names
         assertTrue(GroupName.isValidGroupName("important*")); // contains non-alphanumeric characters
         assertTrue(GroupName.isValidGroupName("^")); // only non-alphanumeric characters
+    }
+
+    @Test
+    public void equal() {
+        Group editedNusFintechSocietyLowerCase = new GroupBuilder(NUS_FINTECH_SOCIETY)
+                .withGroupName(VALID_GROUP_NAME_NUS_FINTECH_SOCIETY.toLowerCase()).build();
+
+        // same group name -> equals
+        assertEquals(NUS_FINTECH_SOCIETY.getGroupName(), NUS_FINTECH_SOCIETY.getGroupName());
+
+        // same group name with different case -> equals
+        assertEquals(NUS_FINTECH_SOCIETY.getGroupName(), editedNusFintechSocietyLowerCase.getGroupName());
     }
 }

--- a/src/test/java/seedu/address/model/group/GroupTest.java
+++ b/src/test/java/seedu/address/model/group/GroupTest.java
@@ -4,16 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.testutil.TypicalGroups.NUS_DATA_SCIENCE_SOCIETY;
 import static seedu.address.testutil.TypicalGroups.NUS_FINTECH_SOCIETY;
-import static seedu.address.testutil.TypicalPersons.BOB;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.model.person.Person;
 import seedu.address.testutil.GroupBuilder;
-import seedu.address.testutil.PersonBuilder;
 
 public class GroupTest {
     @Test

--- a/src/test/java/seedu/address/model/group/GroupTest.java
+++ b/src/test/java/seedu/address/model/group/GroupTest.java
@@ -4,12 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GROUP_NAME_NUS_FINTECH_SOCIETY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.testutil.TypicalGroups.NUS_DATA_SCIENCE_SOCIETY;
 import static seedu.address.testutil.TypicalGroups.NUS_FINTECH_SOCIETY;
+import static seedu.address.testutil.TypicalPersons.BOB;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.person.Person;
 import seedu.address.testutil.GroupBuilder;
+import seedu.address.testutil.PersonBuilder;
 
 public class GroupTest {
     @Test
@@ -57,5 +61,10 @@ public class GroupTest {
         Group editedNusFintechSociety = new GroupBuilder(NUS_FINTECH_SOCIETY)
                 .withGroupName(VALID_GROUP_NAME_NUS_DATA_SCIENCE_SOCIETY).build();
         assertFalse(NUS_FINTECH_SOCIETY.equals(editedNusFintechSociety));
+
+        // group name differs in case, all other attributes same -> returns true
+        Group editedNusFintechSocietyLowerCase = new GroupBuilder(NUS_FINTECH_SOCIETY)
+                .withGroupName(VALID_GROUP_NAME_NUS_FINTECH_SOCIETY.toLowerCase()).build();
+        assertTrue(NUS_FINTECH_SOCIETY.isSameGroup(editedNusFintechSocietyLowerCase));
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -40,9 +40,9 @@ public class PersonTest {
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
 
         // name has trailing spaces, all other attributes same -> returns false
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";


### PR DESCRIPTION
For this modification:
* When comparing whether `Group` objects are the same, the `GroupName` is no longer case sensitive
* When comparing whether `Task` objects are the same, the  `TaskName` is no longer case sensitive