### PR TITLE
Refactor FindCommand, FindCommandParser and UG for Find

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -168,6 +168,7 @@ Locates all student contact in ArchDuke based on attributes that matches the giv
 * The attributes supported are: `n/NAME`, `p/PHONE_NUMER`, `e/EMAIL`, `a/ACADEMIC_MAJOR`, `t/TAG`
 * The specified keywords are **case-insensitive**. 
 * The attributes could be accessed by adding prefixes before the keywords.
+* Only one prefix is allowed (e.g. `find n/Alice p/86472814` will throw an error, but `find n/Alice` or `find p/86472814` will work).
 * The result must match the **exact word**, partial word will not match (e.g. `n/Dav` will not match the student contact
 `David` or `David Li` as there is no word `Dav`).
 * The command will list out all student contacts that matches the keyword.

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -21,9 +21,12 @@ public class FindCommand extends Command {
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Attributes can be accessed by adding prefixes before the keywords.\n"
             + "Parameters: PREFIX/KEYWORD [MORE_KEYWORDS]...\n"
-            + "Note that [MORE_KEYWORDS] only apply for syntax n/ a/ t/ \n"
+            + "Note that [MORE_KEYWORDS] only apply for syntax n/ a/ t/ "
+            + "and only one prefix can be used for find. \n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "alice bob charlie "
             + "or " + COMMAND_WORD + " " + PREFIX_ACADEMIC_MAJOR + "Computer Science";
+
+    public static final String COMMAND_CONTAINS_MULTIPLES_PREFIXES = COMMAND_WORD + " can only take in one prefix.";
 
     private final AttributeContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -23,6 +23,7 @@ import seedu.address.model.tag.TagContainsKeywordsPredicate;
  */
 public class FindCommandParser implements Parser<FindCommand> {
 
+
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
@@ -39,6 +40,12 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (trimmedArgs.isEmpty() || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+
+        if (containsMultiples(args) == true) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                            FindCommand.COMMAND_CONTAINS_MULTIPLES_PREFIXES));
         }
 
         if (args.contains(PREFIX_NAME.getPrefix())) {
@@ -71,6 +78,33 @@ public class FindCommandParser implements Parser<FindCommand> {
         } else {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
+    }
+
+    /**
+     * Checks whether {@code String args} contain multiples prefixes.
+     */
+    public boolean containsMultiples(String args) {
+        int multipleCounts = 0;
+
+        if (args.contains(PREFIX_NAME.getPrefix())) {
+            multipleCounts++;
+        }
+        if (args.contains(PREFIX_PHONE.getPrefix())) {
+            multipleCounts++;
+        }
+        if (args.contains(PREFIX_EMAIL.getPrefix())) {
+            multipleCounts++;
+        }
+        if (args.contains(PREFIX_ACADEMIC_MAJOR.getPrefix())) {
+            multipleCounts++;
+        }
+        if (args.contains(PREFIX_TAG.getPrefix())) {
+            multipleCounts++;
+        }
+        if (multipleCounts > 1) {
+            return true;
+        }
+        return false;
     }
 }
 


### PR DESCRIPTION
FindCommand now throws ParseException when the input has multiple prefixes. For example, "find /n /p". This is due to the bugs found when multiple prefixes are used "find /n /p" will only allow "find /n" to be accessed but not "find /p" due to the code structure. However, this issue can be resolved by only allowing users to use 1 prefix.